### PR TITLE
pymsrc attribute fixes

### DIFF
--- a/pym-shortcode.php
+++ b/pym-shortcode.php
@@ -39,7 +39,7 @@ function pym_shortcode( $atts, $context, $tag ) {
 
 	// If this is the first one on the page, output the pym src
 	// or if the pymsrc is set, output that.
-	if ( 0 === $pym_id || $atts['pymscr'] ) {
+	if ( 0 === $pym_id || ! empty( $atts['pymsrc'] ) ) {
 		echo sprintf(
 			'<script src="%s"></script>',
 			$pymsrc


### PR DESCRIPTION
Not sure why, but the `pymsrc` typo reappeared in https://github.com/INN/pym-shortcode/commit/fcb15b40cbe5c408fa76c580abc5d5ef66dcb23d. This fixes that again. This also checks if the attribute is empty. Otherwise, you get a `Notice: Undefined index: pymsrc` warning if there are multiple Pym shortcodes on a single page.