### PR TITLE
Rename the plugin to "Pym.js Embeds" in most places.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Pym Shortcode
+# Pym.js Embeds
 
-This plugin allows the use of NPR's [Pym.js](http://blog.apps.npr.org/pym.js/) responsive iframe script on WordPress sites, through the use of shortcodes and Gutenberg block.
+This plugin allows the use of NPR's [Pym.js](http://blog.apps.npr.org/pym.js/) responsive iframe script on WordPress sites, through the use of shortcodes and Gutenberg blocks.
 
 For detailed examples, ➡️ [read the docs!](./docs/) ⬅️

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,6 +1,6 @@
-# Pym Shortcode
+# Pym.js Embeds for WordPress
 
-Pym Shortcode will responsively resize an iframe's height depending on the width of its container. The plugin uses [Pym.js](http://blog.apps.npr.org/pym.js/), developed by the [NPR Visuals Team](http://blog.apps.npr.org/), to allow embedded content in WordPress posts and pages using a simple shortcode. Using `Pym.js`, it bypasses the usual cross-domain issues.
+Pym.js Embeds provides shortcode and Gutenberg block wrappers for embedding responsive iframes using [Pym.js](http://blog.apps.npr.org/pym.js/), developed by the NPR Visuals Team. Embedded content resizes vertically to match its container's width.
 
 Contents:
 
@@ -31,13 +31,13 @@ Contents:
 
 ## Plugin Installation
 
-1. In the WordPress Dashboard go to **Plugins**, then click the **Add Plugins** button and search the WordPress Plugins Directory for Pym Shortcode. Alternatively, you can download the zip file from this Github repo and upload it manually to your WordPress site.
-2. Activate the plugin through the 'Plugins' screen in WordPress
-3. Nothing to configure, just begin using Pym Shortcode!
+1. In the WordPress Dashboard go to **Plugins**, then click the **Add Plugins** button and search the WordPress Plugins Directory for Pym.js Embeds. Alternatively, you can download the zip file from this Github repo and upload it manually to your WordPress site.
+2. Activate the plugin through the 'Plugins' screen in WordPress.
+3. Nothing to configure, just begin using Pym.js Embeds!
 
 ## The Pym Shortcode
 
-In a WordPress post or page use Pym Shortcode like this:
+In a WordPress post or page, use Pym Shortcode like this:
 
 `[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html"]`
 
@@ -51,7 +51,7 @@ Example in a post:
 
 ![Screenshot of the Pym Embed block in a post, with the block settings pane opened to show the block's options and advanced options](img/block-in-editor.png)
 
-For the block, all options available via shortcode arguments are available through the block's advanced options panel.
+For the block, all options available via shortcode arguments are available through the block's Advanced Options panel.
 
 ## Options
 
@@ -73,7 +73,7 @@ Here's what the setting looks like in a block:
 
 ![A Pym embed block in use in a post, showing its alignment controls](img/block.png)
 
-### `pymsrc`, the URL for pym.js
+### `pymsrc`, the URL for Pym.js
 
 `pymsrc` is optional; only set this if you need to specify a different source for `Pym.js` than the default. The default `Pym.js` source URL is `js/pym.v1.min.js` in this plugin's directory on your server. [NPR recommends](http://blog.apps.npr.org/pym.js/#get-pym-cdn) that you use the CDN version of `Pym.js` in most cases, which is available at `https://pym.nprapps.org/pym.v1.min.js`. An example shortcode using this option is as follows:
 
@@ -81,7 +81,7 @@ Here's what the setting looks like in a block:
 [pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" pymsrc="https://pym.nprapps.org/pym.v1.min.js"]
 ```
 
-### `pymoptions`, settings for Pym
+### `pymoptions`, settings for Pym.js
 
 `pymoptions` is optional; this should be a javascript object without the surrounding `{}`, and is given in the event that options need to be passed to the `pymParent`. NPR gives [this example](http://blog.apps.npr.org/pym.js/#examples) javascript:
 
@@ -89,7 +89,7 @@ Here's what the setting looks like in a block:
 pym.Parent('example', 'https://blog.apps.npr.org/pym.js/examples/table/child.html', { xdomain: '*\.npr\.org' });
 ```
 
-To do the same thing with this Pym shortcode, you would write:
+To do the same thing with this Pym Shortcode, you would write:
 
 ```
 [pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" pymoptions=" xdomain: '\\*\.npr\.org' "]
@@ -127,25 +127,25 @@ For example, the shortcode `[pym src="https://blog.apps.npr.org/pym.js/examples/
 
 ## Frequently Asked Questions
 
-### Why would I want to use Pym in the first place?
+### Why would I want to use Pym.js in the first place?
 
 Using iframes in a responsive page can be frustrating. It’s easy enough to make an iframe’s width span 100% of its container, but sizing its height is tricky — especially if the content of the iframe changes height depending on page width (for example, because of text wrapping or media queries) or events within the iframe. For more information, see [NPR's documentation for `Pym.js`](http://blog.apps.npr.org/pym.js).
 
 ### Why is a WordPress plugin needed to use `Pym.js`?
 
-Normally WordPress strips out JavaScript inserted in posts and pages, so the usual HTML `Pym.js` embed code's `<script>` tag won't work. Pym Shortcode simply provides a wrapper around `Pym.js` so you can embed anything you'd use `Pym.js` for by using WordPress shortcode.
+Normally WordPress strips out JavaScript inserted in posts and pages, so the usual HTML `Pym.js` embed code's `<script>` tag won't work. Pym.js Embeds simply provides a wrapper around `Pym.js` so you can embed anything you'd use `Pym.js` for by using WordPress shortcodes or blocks.
 
 ### When would I use a `Pym.js` solution versus embed code without using `Pym.js`?
 
-If you're embedding a YouTube video or a SoundCloud audio player, you don't need `Pym.js` and in fact, you would not want to use it. WordPress supports many embeds through [oEmbed](https://codex.wordpress.org/Embeds). To make these commodity types of embeds responsive, you may need to add CSS rules depending on your theme. They won't be resized by this plugin.
+If you're embedding a YouTube video or a SoundCloud audio player, you don't need `Pym.js` and in fact, you would not want to use it. WordPress supports many embeds through [oEmbed](https://codex.wordpress.org/Embeds). To make these commodity types of embeds responsive, you may need to add CSS rules depending on your theme. Embeds not built with `Pym.js` won't be resized by this plugin.
 
-You would want to use Pym for other types of content you create and embed using iframes such as tables, charts, and interactive elements. For example, news organizations often create data-driven visualizations that are hosted in another application and need to be iframed into their CMS.
+You would want to use `Pym.js` for other types of content you create and embed using iframes such as tables, charts, and interactive elements. For example, news organizations often create data-driven visualizations that are hosted in another application and need to be iframed into their CMS.
 
 For the Pym shortcode or the Pym block to work, the `Pym.js` JavaScript library must be used on the embedded page, referred to as the "child page". You can use this plugin's shortcode or block to embed content from any page that is so enabled. For information on how to use `Pym.js` in your projects, see [NPR's `Pym.js` documentation](http://blog.apps.npr.org/pym.js/#examples).
 
 ### Is `Pym.js` or this plugin dependent on jQuery or any other library?
 
-Nope, all the required JavaScript is self-contained in the plugin-provided copy of `pym.v1.min.js`. The shortcode will enqueue `pym.v1.min.js` when necessary. You will need to include `pym.v1.min.js` on the embedded page, however.
+Nope, all the required JavaScript is self-contained in the plugin-provided copy of `pym.v1.min.js`. The shortcode will enqueue `pym.v1.min.js` on the parent page when necessary. You will need to include `pym.v1.min.js` on the embedded page, however.
 
 ### What is the URL for `pym.v1.min.js`?
 
@@ -157,13 +157,13 @@ Or, you can specify the URL from which to load `Pym.js`.
 
 ### What is the difference between `Pym.js` and `pym.v1.min.js`?
 
-In this document, `Pym.js` is used to refer to the JavaScript library.
+In this document, `Pym.js` is used to refer to the JavaScript library. "Pym.js Embeds" is the name of this plugin.
 
 `pym.v1.min.js` is a specific copy of that library, hosted on your server at a given URL. It's named following [NPR's `Pym.js` versioning strategy](https://github.com/nprapps/pym.js/tree/master#versioning). It is kept up to date with the CDN version of the library by this plugin's maintainers, [following these instructions](https://github.com/INN/pym-shortcode/blob/master/docs/updating-pym.md).
 
 The CDN version of `Pym.js` is at https://pym.nprapps.org/pym.v1.min.js .
 
-Also in this plugin is `js/pym.js`, which is `Pym.js` version 1.1.0, and which is kept around for legacy support for graphics created before this plugin had a defined update strategy.
+Also included in this plugin is `js/pym.js`, which is `Pym.js` version 1.1.0, and which is kept around for legacy support for graphics created before this plugin had a defined update strategy.
 
 ### Why would I want to change the `Pym.js` source URL?
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -5,18 +5,18 @@ Pym.js Embeds provides shortcode and Gutenberg block wrappers for embedding resp
 Contents:
 
 1. [Plugin Installation](#plugin-installation)
-2. [The Pym Shortcode](#the-pym-shortcode)
-3. [The Pym Block](#the-pym-block)
+2. [The Pym.js Shortcode](#the-pym-shortcode)
+3. [The Pym.js Block](#the-pym-block)
 4. [Embed Options](#embed-options)
 	1. [src: the only required argument](#src-the-child-url-required-argument)
 	2. [pymsrc](#pymsrc-the-url-for-pymjs)
-	3. [pymoptions](#pymoptions-settings-for-pym)
-	4. [class](#class-to-add-html-classes-to-the-pym-parent-element)
+	3. [pymoptions](#pymoptions-settings-for-pymjs)
+	4. [class](#class-to-add-html-classes-to-the-pymjs-parent-element)
 	5. [align](#align-for-wordpress-alignment-support)
 	6. [id](#id-to-set-the-pym-parent-elements-id)
 5. [Plugin Options](#plugin-options)
 5. [Frequently Asked Questions](#frequently-asked-questions)
-	1. [Why would I want to use Pym in the first place?](#why-would-i-want-to-use-pym-in-the-first-place)
+	1. [Why would I want to use Pym.js in the first place?](#why-would-i-want-to-use-pym-in-the-first-place)
 	2. [Why is a WordPress plugin needed to use Pym.js?](#why-is-a-wordpress-plugin-needed-to-use-pymjs)
 	3. [When would I use a Pym.js solution versus embed code without using Pym.js?](#when-would-i-use-a-pymjs-solution-versus-embed-code-without-using-pymjs)
 	4. [Is Pym.js or this plugin dependent on jQuery or any other library?](#is-pymjs-or-this-plugin-dependent-on-jquery-or-any-other-library)
@@ -28,7 +28,7 @@ Contents:
 	9. [How do I know if there's an HTTPS problem with a given embedded iframe?](#how-do-i-know-if-theres-an-https-problem-with-a-given-embedded-iframe)
 	10. [What license is this plugin licensed under?](#what-license-is-this-plugin-licensed-under)
 	11. [How do I contribute to this plugin?](#how-do-i-contribute-to-this-plugin)
-6. [Other Pym Resources](#other-pym-resources)
+6. [Other Pym.js Resources](#other-pymjs-resources)
 
 ## Plugin Installation
 
@@ -36,21 +36,21 @@ Contents:
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 3. Nothing to configure, just begin using Pym.js Embeds!
 
-## The Pym Shortcode
+## The Pym.js Shortcode
 
-In a WordPress post or page, use Pym Shortcode like this:
+In a WordPress post or page, use the Pym.js Shortcode like this:
 
 `[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html"]`
 
 Example in a post:
 
-![Pym Shortcode in a WordPress post](img/pym-shortcode-in-post.png)
+![Pym.js Shortcode in a WordPress post](img/pym-shortcode-in-post.png)
 
-## The Pym Block
+## The Pym.js Block
 
 Example in a post:
 
-![Screenshot of the Pym Embed block in a post, with the block settings pane opened to show the block's options and advanced options](img/block-in-editor.png)
+![Screenshot of the Pym.js Embed block in a post, with the block settings pane opened to show the block's options and advanced options](img/block-in-editor.png)
 
 For the block, all options available via shortcode arguments are available through the block's Advanced Options panel.
 
@@ -72,7 +72,7 @@ For the shortcode, `src` is the only required parameter.
 
 Here's what the setting looks like in a block:
 
-![A Pym embed block in use in a post, showing its alignment controls](img/block.png)
+![A Pym.js embed block in use in a post, showing its alignment controls](img/block.png)
 
 ### `pymsrc`, the URL for Pym.js
 
@@ -90,15 +90,15 @@ Here's what the setting looks like in a block:
 pym.Parent('example', 'https://blog.apps.npr.org/pym.js/examples/table/child.html', { xdomain: '*\.npr\.org' });
 ```
 
-To do the same thing with this Pym Shortcode, you would write:
+To do the same thing with this Pym.js Shortcode, you would write:
 
 ```
 [pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" pymoptions=" xdomain: '\\*\.npr\.org' "]
 ```
 
-### `class`, to add HTML classes to the Pym parent element
+### `class`, to add HTML classes to the Pym.js parent element
 
-`class` is optional; this should be a valid HTML class name. It will be added to the element's default class, `'pym'`. You would want to use this if, for example, you wanted to [use a size-based class name to determine the size of the embed on your site](https://github.com/INN/pym-shortcode/issues/23). The class `'pym'` will always be output on container elements created by the Pym Shortcode. This class was introduced in version 1.2.2.
+`class` is optional; this should be a valid HTML class name. It will be added to the element's default class, `'pym'`. You would want to use this if, for example, you wanted to [use a size-based class name to determine the size of the embed on your site](https://github.com/INN/pym-shortcode/issues/23). The class `'pym'` will always be output on container elements created by the Pym.js Shortcode. This class was introduced in version 1.2.2.
 
 For example, the shortcode `[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" class="one two three four float-left mw_50"]` results in the following output:
 
@@ -112,13 +112,13 @@ If you do not want the class `'pym'` output on container elements, [add a filter
 
 ### `align`, for WordPress alignment support
 
-`align` is optional; this should be one of the [WordPress-provided generated alignment types](https://codex.wordpress.org/CSS#WordPress_Generated_Classes): `left`, `right`, `center`, `none`. If your theme supports the `wide` or `full` values, you can use those too, as the value provided here will be prefixed with `align` and output as a CSS class on the Pym parent, so that the shortcode `[pym align="foo"]` results in the output `<div id="pym_0" class="pym alignfoo ">...`
+`align` is optional; this should be one of the [WordPress-provided generated alignment types](https://codex.wordpress.org/CSS#WordPress_Generated_Classes): `left`, `right`, `center`, `none`. If your theme supports the `wide` or `full` values, you can use those too, as the value provided here will be prefixed with `align` and output as a CSS class on the Pym.js parent, so that the shortcode `[pym align="foo"]` results in the output `<div id="pym_0" class="pym alignfoo ">...`
 
 In the Gutenberg editor, the alignment options are provided by the alignment controls that appear when the block is selected. The default choice is "none", with no option selected, and the other options are to align it left, center, or right. If your theme [declares support for the "wide" alignment](https://wordpress.org/gutenberg/handbook/extensibility/theme-support/#wide-alignment), you'll also see options for "wide" and "full" widths. The appearance of these alignment options on the page will depend on your site's theme.
 
-![A Pym embed block in use in a post, showing its alignment controls](img/block.png)
+![A Pym.js embed block in use in a post, showing its alignment controls](img/block.png)
 
-### `id`, to set the Pym parent element's ID
+### `id`, to set the Pym.js parent element's ID
 
 `id` is optional; this should be a valid HTML element ID name. It will be used as the ID of your `pymParent` iframe on the parent page. You would want to use this if, for example, [your embedded page contained navigation to another page, requiring the second page to know the pymParent element ID](https://github.com/INN/pym-shortcode/issues/20).
 
@@ -170,7 +170,7 @@ If you're embedding a YouTube video or a SoundCloud audio player, you don't need
 
 You would want to use `Pym.js` for other types of content you create and embed using iframes such as tables, charts, and interactive elements. For example, news organizations often create data-driven visualizations that are hosted in another application and need to be iframed into their CMS.
 
-For the Pym shortcode or the Pym block to work, the `Pym.js` JavaScript library must be used on the embedded page, referred to as the "child page". You can use this plugin's shortcode or block to embed content from any page that is so enabled. For information on how to use `Pym.js` in your projects, see [NPR's `Pym.js` documentation](http://blog.apps.npr.org/pym.js/#examples).
+For the Pym.js shortcode or the Pym.js block to work, the `Pym.js` JavaScript library must be used on the embedded page, referred to as the "child page". You can use this plugin's shortcode or block to embed content from any page that is so enabled. For information on how to use `Pym.js` in your projects, see [NPR's `Pym.js` documentation](http://blog.apps.npr.org/pym.js/#examples).
 
 ### Is `Pym.js` or this plugin dependent on jQuery or any other library?
 
@@ -182,7 +182,7 @@ Assuming that you have installed this plugin via the wordpress.org plugin reposi
 
 You can check the validity of that assumption by putting a shortcode or block in a post, then viewing the post from the frontend. In the source code of the page, you should see a script tag loading `pym.v1.min.js`. 
 
-The URL can also be found on the "Pym Plugin Info" page, found under the "Tools" menu in your site's admin dashboard.
+The URL can also be found on the "Pym.js Plugin Info" page, found under the "Tools" menu in your site's admin dashboard.
 
 Or, you can specify the URL from which to load `Pym.js`.
 
@@ -213,9 +213,9 @@ In any of these cases, set the different version of `Pym.js` using the `pymsrc` 
 
 ### I've set a different `pymsrc` option, but now I'm seeing a message in the console
 
-If a post has multiple instances of the Pym shortcode or block present, and between those different Pym instances there are different source URLs for `Pym.js` specified, then you should expect to see a message like the following in the browser's console when viewing that page:
+If a post has multiple instances of the Pym.js shortcode or block present, and between those different Pym.js instances there are different source URLs for `Pym.js` specified, then you should expect to see a message like the following in the browser's console when viewing that page:
 
-> Hi Pym user! It looks like your post has multiple values for pymsrc for the blocks and shortcodes in use on this page. This may be causing problems for your Pym embeds. For more details, see https://github.com/INN/pym-shortcode/tree/master/docs#ive-set-a-different-pymsrc-option-but-now-im-seeing-a-message-in-the-console"
+> Hi Pym.js user! It looks like your post has multiple values for pymsrc for the blocks and shortcodes in use on this page. This may be causing problems for your Pym.js embeds. For more details, see https://github.com/INN/pym-shortcode/tree/master/docs#ive-set-a-different-pymsrc-option-but-now-im-seeing-a-message-in-the-console"
 
 If your server is running with [`WP_DEBUG` set to `true`](https://codex.wordpress.org/WP_DEBUG), then your server console will also contain a message like this:
 
@@ -231,9 +231,9 @@ This message is included to make the process of debugging your content easier.
 To remedy this issue, take the following steps:
 
 1. Make sure every `[pym]` shortcode in the page has the same `pymsrc=""` attribute
-2. Make sure that every Pym Embed block on the page has the same URL set in the block settings for the "Pym.js URL" option.
+2. Make sure that every Pym.js Embed block on the page has the same URL set in the block settings for the "Pym.js URL" option.
 
-If your post has a mix of Pym shortcodes and blocks, you'll need to make sure that both types of Pym embed on the page use the same source URL.
+If your post has a mix of Pym.js shortcodes and blocks, you'll need to make sure that both types of Pym.js embed on the page use the same source URL.
 
 ### How do I serve `Pym.js` if the embedded page uses HTTPS and my site does not?
 
@@ -265,7 +265,7 @@ This plugin is released under the GNU GPL, version 2 or later.
 
 We welcome your contributions; please see [the contribution instructions](../contributing.md).
 
-## Other Pym Resources
+## Other Pym.js Resources
 
 You may also want to look at NPR's `Pym.js` resources, especially if you're interested in building compatible embeds:
 

--- a/inc/block.php
+++ b/inc/block.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * The Gutenberg block for Pym embeds
+ * The Gutenberg block for Pym.js embeds
  *
- * @package pym-shortcode
+ * @package pym-embeds
  */
 
 /**

--- a/inc/class-pymsrc-output.php
+++ b/inc/class-pymsrc-output.php
@@ -2,7 +2,7 @@
 /**
  * The class and related methods for tracking which pymsrc tags will be output upon the page
  *
- * @package pym-shortcode
+ * @package pym-embeds
  */
 
 /**
@@ -129,13 +129,13 @@ class Pymsrc_Output{
 	/**
 	 * Output a thing in the footer that shows up in the browser console, to assist in debugging
 	 *
-	 * This has to support IE 9 because Pym supports IE 9, but `console.log` and `console.error` aren't available in IE 9 unless the dev tools are open. Thus, the check `window.console`.
+	 * This has to support IE 9 because Pym.js supports IE 9, but `console.log` and `console.error` aren't available in IE 9 unless the dev tools are open. Thus, the check `window.console`.
 	 * @link https://stackoverflow.com/questions/8002116/should-i-be-removing-console-log-from-production-code/15771110
 	 */
 	public function warning_message_footer() {
 		printf(
 			'<script type="text/javascript">window.console && console.log( \'%1$s\', %2$s );</script>',
-			wp_json_encode( __( 'Hi Pym user! It looks like your post has multiple values for pymsrc for the blocks and shortcodes in use on this page. This may be causing problems for your Pym embeds. For more details, see https://github.com/INN/pym-shortcode/tree/master/docs#ive-set-a-different-pymsrc-option-but-now-im-seeing-a-message-in-the-console', 'pym_shortcode' ) ),
+			wp_json_encode( __( 'Hi Pym.js user! It looks like your post has multiple values for pymsrc for the blocks and shortcodes in use on this page. This may be causing problems for your Pym.js embeds. For more details, see https://github.com/INN/pym-shortcode/tree/master/docs#ive-set-a-different-pymsrc-option-but-now-im-seeing-a-message-in-the-console', 'pym_shortcode' ) ),
 			wp_json_encode( $this->sources )
 		);
 	}

--- a/inc/info-page.php
+++ b/inc/info-page.php
@@ -3,6 +3,8 @@
  * The informational page for this plugin.
  *
  * This is available to everyone who can edit posts, because they'll need this info if they're creating new child pages for embed using the shortcode or plugin.
+ *
+ * @package pym-embeds
  */
 
 namespace INN\PymEmbeds\Info;

--- a/inc/settings-page.php
+++ b/inc/settings-page.php
@@ -2,6 +2,7 @@
 /**
  * The settings page for this plugin.
  *
+ * @package pym-embeds
  */
 
 namespace INN\PymEmbeds\Settings;

--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -2,7 +2,7 @@
 /**
  * The [pym] shortcode and related functions
  *
- * @package pym-shortcode
+ * @package pym-embeds
  */
 
  use INN\PymEmbeds\Settings\option_key;
@@ -10,7 +10,8 @@
 /**
  * A shortcode to simplify the process of embedding articles using pym.js
  *
- * This function also powers the Pym Embed block output.
+ * This function also powers the Pym.js Embed block output in Gutenberg,
+ * as the render callback for a dynamic block.
  *
  * @param Array  $atts    the attributes passed in the shortcode.
  * @param String $content the enclosed content; should be empty for this shortcode.
@@ -72,8 +73,10 @@ function pym_shortcode( $atts = array(), $content = '', $tag = '' ) {
 		$pymsrc = $atts['pymsrc'];
 	}
 
-	// If this is the first Pym element on the page, output the pymsrc script tag
-	// or if the pymsrc is set, output that.
+	// If this is the first Pym.js element on the page,
+	// register the default pymsrc script tag for output.
+	//
+	// Or, if the pymsrc is set, register that specific pymsrc for output.
 	if ( 0 === $pym_id || ! empty( $atts['pymsrc'] ) ) {
 		$pymsrc_output = Pymsrc_Output::get_instance();
 		$pymsrc_output->add( $pymsrc );
@@ -111,19 +114,19 @@ add_shortcode( 'pym', 'pym_shortcode' );
  * @link https://github.com/INN/pym-shortcode/issues/19
  *
  * @param Array $args Has the following indices:
- *     - 'pym_id' Which Pym instance this is on the page, provided for
+ *     - 'pym_id' Which Pym.js embed instance this is on the page, provided for
  *        informational purposes. In this function, the pym_id value is
  *        used as the variable name in `var pym_id = new pym.Parent(...);`
- *     - 'actual_id' the element ID used for the Pym container element,
+ *     - 'actual_id' the element ID used for the Pym.js container element,
  *        which is at this point set on the page and not changeable from
  *        this function. This is the first argument for `new pym.Parent()`.
- *     - 'src' the URL for the Pym child page. This is the second argument
+ *     - 'src' the URL for the Pym.js child page. This is the second argument
  *        for `new pym.Parent()`.
  *     - 'pymoptions' The third argument for `pym.Parent()` See the xdomain
  *        argument in http://blog.apps.npr.org/pym.js/#example-block
- *     - 'actual_classes' The classes used on the Pym container element,
+ *     - 'actual_classes' The classes used on the Pym.js container element,
  *        provided to this function for informational purposes.
- *     - 'pymsrc' The URL from which Pym is to be loaded for this emebed,
+ *     - 'pymsrc' The URL from which Pym.js is to be loaded for this emebed,
  *        based on the shortcode/block options and the plugin settings.
  *
  * @since 1.3.2.1

--- a/js/block.js
+++ b/js/block.js
@@ -49,7 +49,7 @@
 		 * This is the display title for your block, which can be translated with `i18n` functions.
 		 * The block inserter will show this name.
 		 */
-		title: __( 'Pym Embed' ),
+		title: __( 'Pym.js Embed' ),
 
 		/**
 		 * An icon property should be specified to make it easier to identify a block.
@@ -114,10 +114,10 @@
 									icon: 'analytics'
 								},
 							),
-							__( 'Pym Child URL' )
+							__( 'Pym.js Child URL' )
 						],
 						value: props.attributes.src,
-						placeholder: __( 'What is the URL of your Pym child page?' ),
+						placeholder: __( 'What is the URL of your Pym.js child page?' ),
 						onChange: ( value ) => { props.setAttributes( { src: value } ); },
 					} )
 				),
@@ -130,26 +130,26 @@
 				 */
 				el( InspectorControls, {},
 					el( TextControl, {
-						label: __( 'Pym Child URL' ),
+						label: __( 'Pym.js Child URL' ),
 						value: props.attributes.src,
-						placeholder: __( 'What is the URL of your Pym child page?' ),
+						placeholder: __( 'What is the URL of your Pym.js child page?' ),
 						onChange: ( value ) => { props.setAttributes( { src: value } ); },
 					} ),
 				),
 				el( InspectorAdvancedControls, {},
 					el( TextControl, {
-						label: __( 'Parent element ID (optional)' ),
+						label: __( 'Parent Element ID (optional)' ),
 						value: props.attributes.id,
 						onChange: ( value ) => { props.setAttributes( { id: value } ); },
-						help: __( 'The Pym block will automatically generate an ID for the parent element and use that to initiate the Pym embed. If your child page\'s code requires its parent to have a specific element ID, set that here.' ),
+						help: __( 'The Pym.js block will automatically generate an ID for the parent element and use that to initiate the Pym.js embed. If your child page\'s code requires its parent to have a specific element ID, set that here.' ),
 					} ),
 					el( TextControl, {
-						label: __( 'Pym.js source URL (optional)' ),
+						label: __( 'Pym.js Source URL (optional)' ),
 						value: props.attributes.pymsrc,
 						onChange: ( value ) => { props.setAttributes( { pymsrc: value } ); },
 					} ),
 					el( TextControl, {
-						label: __( 'Pym Options' ),
+						label: __( 'Pym.js Options' ),
 						value: props.attributes.pymoptions,
 						onChange: ( value ) => { props.setAttributes( { pymoptions: value } ); },
 						// @todo make this translatable https://github.com/WordPress/gutenberg/blob/master/packages/i18n/README.md

--- a/pym-shortcode.php
+++ b/pym-shortcode.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: Pym Shortcode
+Plugin Name: Pym.js Embeds
 Plugin URI: https://github.com/INN/pym-shortcode
 Description: Adds a [pym src=""] shortcode to simplify use of NPR's Pym.js
 Version: 1.3.2

--- a/readme.txt
+++ b/readme.txt
@@ -32,17 +32,17 @@ Embeddable table from NPR:
 
 ![an embeddable table from NPR](img/responsive-iframe-npr.png)
 
-Pym Shortcode in a WordPress post:
+Pym.js Shortcode in a WordPress post:
 
-![Pym Shortcode in a WordPress post](img/pym-shortcode-in-post.png)
+![Pym.js Shortcode in a WordPress post](img/pym-shortcode-in-post.png)
 
-Desktop view of the WordPress post with the NPR embed using Pym Shortcode:
+Desktop view of the WordPress post with the NPR embed using Pym.js Shortcode:
 
-![Desktop view of the WordPress post with the NPR embed using Pym Shortcode](img/pym-example-desktop.png)
+![Desktop view of the WordPress post with the NPR embed using Pym.js Shortcode](img/pym-example-desktop.png)
 
-Mobile view of the WordPress post with the NPR embed using Pym Shortcode:
+Mobile view of the WordPress post with the NPR embed using Pym.js Shortcode:
 
-![Mobile view of the WordPress post with the NPR embed using Pym Shortcode](img/pym-example-phone.png)
+![Mobile view of the WordPress post with the NPR embed using Pym.js Shortcode](img/pym-example-phone.png)
 
 == Changelog ==
 
@@ -54,10 +54,8 @@ Following the practice begun at plugin version 1.1.2 of [having the plugin versi
 
 New features:
 
-Adds Gutenberg support.
-
 * Plugin renamed from "Pym Shortcode" to "Pym.js Embeds".
-* Adds a "Pym Embed" block for use in Gutenberg. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issue [#28](https://github.com/INN/pym-shortcode/issues/28).
+* Adds a "Pym.js Embed" block for use in Gutenberg. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issue [#28](https://github.com/INN/pym-shortcode/issues/28).
 	* If a block is created using this plugin and Gutenberg, and Gutenberg is then disabled, the block will show a link to the embedded graphic.
 * Through the settings page, you can now serve pym.js using your newsroom's CDN or NPR's CDN! [PR #45]() for [issue #31](https://github.com/INN/pym-shortcode/issues/31).
 * Adds a settings page, available to those with the `manage_options` capability, with the following options:
@@ -80,7 +78,7 @@ Changes:
 
 = 1.3.2 =
 
-* *RECOMMENDED UPDATE* : Pym users, NPR has released an update that closes a potential security hole. We recommend everyone update to 1.3.2.
+* *RECOMMENDED UPDATE* : Pym.js users, NPR has released an update that closes a potential security hole. We recommend everyone update to 1.3.2.
 * Update to pym.js version 1.3.2: https://github.com/nprapps/pym.js/releases/tag/v1.3.2 (Changelog at https://github.com/nprapps/pym.js/blob/v1.3.2/CHANGELOG)
 
 = 1.3.1 =
@@ -121,11 +119,7 @@ Changes:
 
 * First release of the plugin
 
-== Upgrade Notice ==
-
-No updates at this time.
-
-== Pym Resources from NPR ==
+== Pym.js Resources from NPR ==
 
 You may also want to look at NPR's Pym.js resources:
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Pym Shortcode ===
+=== Pym.js Embeds ===
 Contributors: inn_nerds
 Donate link: https://inn.org/donate
 Tags: shortcode, iframe, javascript, embeds, responsive, pym, NPR
@@ -8,17 +8,17 @@ Stable tag: 1.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-A WordPress solution to embed iframes that are responsive horizontally and vertically using the NPR Visuals Team's pym.js.
+A WordPress solution to embed iframes that are responsive horizontally and vertically using the NPR Visuals Team's `Pym.js`.
 
 == Description ==
 
-Pym Shortcode will resize an iframe responsively depending on the height of its content and the width of its container. The plugin uses [Pym.js](http://blog.apps.npr.org/pym.js/), developed by the NPR Visuals Team, to allow embedded content in WordPress posts and pages using a simple shortcode.
+Pym.js Embeds provides shortcode and Gutenberg block wrappers for embedding responsive iframes using [Pym.js](http://blog.apps.npr.org/pym.js/), developed by the NPR Visuals Team. Embedded content resizes vertically to match its container's width.
 
 == Installation ==
 
-1. In the WordPress Dashboard go to **Plugins**, then click the **Add Plugins** button and search the WordPress Plugins Directory for Pym Shortcode. Alternatively, you can download the zip file from this Github repo and upload it manually to your WordPress site.
+1. In the WordPress Dashboard go to **Plugins**, then click the **Add Plugins** button and search the WordPress Plugins Directory for Pym.js Embeds. Alternatively, you can download the zip file from this Github repo and upload it manually to your WordPress site.
 2. Activate the plugin through the 'Plugins' screen in WordPress
-3. Nothing to configure, just begin using Pym Shortcode!
+3. Nothing to configure, just begin using Pym.js Embeds!
 
 == Frequently Asked Questions ==
 
@@ -46,6 +46,9 @@ Mobile view of the WordPress post with the NPR embed using Pym Shortcode:
 
 = [unreleased] =
 
+Adds Gutenberg support.
+
+* Plugin renamed from "Pym Shortcode" to "Pym.js Embeds".
 * Adds a "Pym Embed" block for use in Gutenberg. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issue [#28](https://github.com/INN/pym-shortcode/issues/28).
 * Shortcode now gains an `align=""` parameter, so that WordPress's generated [alignment CSS classes](https://codex.wordpress.org/CSS#WordPress_Generated_Classes) can be used on embeds. By enabling this in the shortcode, the Gutenberg Block also gains support for alignment. [PR #34](https://github.com/INN/pym-shortcode/pull/34)
 * Script tags for embeds are no longer output by `the_content()`, instead being output during `wp_footer()` by [closures](https://secure.php.net/manual/en/functions.anonymous.php) hooked on the `'wp_footer'` action. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issues [#33](https://github.com/INN/pym-shortcode/issues/33) and [#35](https://github.com/INN/pym-shortcode/issues/35).


### PR DESCRIPTION
This name is chosen becuse it lacks the clunkiness of "shortcode and block".

In an email from Alyson Hurt, NPR Visuals Team member:

> I'm afraid I don't know enough about WordPress and user/developer community expectations to be able to weigh in with an informed opinion on the naming question. All that said, your suggestion of "Pym.js embeds" gets around the shortcode vs. block question entirely and might be a reasonable way to go.

And that's good enough for me.

Resolves https://github.com/INN/pym-shortcode/issues/39