### PR TITLE
Options page and settings

### DIFF
--- a/docs/maintainer-notes.md
+++ b/docs/maintainer-notes.md
@@ -1,4 +1,6 @@
-## Notes for Plugin maintainers
+# Notes for Plugin maintainers
+
+### Updating Pym.js
 
 `js/pym.v1.min.js` in this plugin should be kept up-to-date with the current version of https://pym.nprapps.org/pym.v1.min.js.
 
@@ -10,3 +12,18 @@ To update:
 - update this plugin's version number to the `Pym.js` version number
 
 NPR Visuals Team's [stated intention](https://github.com/nprapps/pym.js/tree/master#versioning) is that versions of `Pym.js` will be backwards-compatible for `0.x` and `0.0.x` releases, so we can copy those in directly. When a `x.0.0` release comes around, we'll need to figure out a plan for that. See discussion in https://github.com/INN/pym-shortcode/issues/12
+
+### Updating the plugin
+
+The plugin's `A.B.C` version number should match the version number of the bundled copy of `Pym.js`. We started doing this in plugin release 1.1.2.
+
+The plugin's [version history](https://github.com/INN/pym-shortcode/releases) looks like this:
+
+- 0.1: initial release
+- 1.1.2
+- 1.2.0
+- 1.2.0.1: a fix in this plugin
+- 1.2.0.2: a fix in this plugin
+- 1.3.1
+- 1.3.2
+- 1.3.2.1: Gutenberg and settings page

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -152,6 +152,8 @@ Assuming that you have installed this plugin via the wordpress.org plugin reposi
 
 You can check the validity of that assumption by putting a shortcode or block in a post, then viewing the post from the frontend. In the source code of the page, you should see a script tag loading `pym.v1.min.js`. 
 
+The URL can also be found on the "Pym Plugin Info" page, found under the "Tools" menu in your site's admin dashboard.
+
 Or, you can specify the URL from which to load `Pym.js`.
 
 ### Why would I want to change the `Pym.js` source URL?

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -7,13 +7,14 @@ Contents:
 1. [Plugin Installation](#plugin-installation)
 2. [The Pym Shortcode](#the-pym-shortcode)
 3. [The Pym Block](#the-pym-block)
-4. [Options](#options)
-	1. [src: the only required argument](#src-the-child-url)
-	2. pymsrc
-	3. pymoptions
-	4. class
-	5. align
-	6. id
+4. [Embed Options](#embed-options)
+	1. [src: the only required argument](#src-the-child-url-required-argument)
+	2. [pymsrc](#pymsrc-the-url-for-pymjs)
+	3. [pymoptions](#pymoptions-settings-for-pym)
+	4. [class](#class-to-add-html-classes-to-the-pym-parent-element)
+	5. [align](#align-for-wordpress-alignment-support)
+	6. [id](#id-to-set-the-pym-parent-elements-id)
+5. [Plugin Options](#plugin-options)
 5. [Frequently Asked Questions](#frequently-asked-questions)
 	1. [Why would I want to use Pym in the first place?](#why-would-i-want-to-use-pym-in-the-first-place)
 	2. [Why is a WordPress plugin needed to use Pym.js?](#why-is-a-wordpress-plugin-needed-to-use-pymjs)
@@ -53,7 +54,7 @@ Example in a post:
 
 For the block, all options available via shortcode arguments are available through the block's advanced options panel.
 
-## Options
+## Embed Options
 
 ```
 [pym src="" pymsrc="" pymoptions="" class="" align="" id="" ]
@@ -124,6 +125,30 @@ For example, the shortcode `[pym src="https://blog.apps.npr.org/pym.js/examples/
 ```html
 <div id="extremely_specific_id" class="pym"></div><script src="http://example.org/wp-content/plugins/pym-shortcode/js/pym.v1.min.js"></script><script>var pym_0 = new pym.Parent('extremely_specific_example', 'https://blog.apps.npr.org/pym.js/examples/table/child.html', {})</script>
 ```
+
+## Plugin Options
+
+The Pym.js Embed Settings page can be found under WordPress' "Settings" menu.
+
+The settings page provides two options: the default pymsrc and the option to override all pymsrc arguments.
+
+We **strongly recommend** that you set the default pymsrc to `https://pym.nprapps.org/pym.v1.min.js` and check the box to enable the pymsrc override.
+
+### Default pymsrc
+
+As explained in the documentation for [the pymsrc embed option](#pymsrc-the-url-for-pymjs), the default copy of `Pym.js` used by this plugin is the copy bundled with this plugin. NPR recommends, and we recommend, that you use the copy of `Pym.js` provided by NPR's CDN. However, this plugin cannot force you to do so; the WordPress.org plugin guidelines generally [prohibit plugin use of third-party scripts without user consent](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#7-plugins-may-not-track-users-without-their-consent), and frown upon plugins that use CDNs by default. Therefore, we give you the option to use NPR's CDN, or your nwesroom's CDN, and ship the plugin in a state that defaults to no CDN.
+
+Shortcodes and blocks have the the option to specify an alternate source for `Pym.js` at a per-embed level, which allows you to opt into using the CDN version of the script on a per-embed level. This is less than optimal; every time you create a `Pym.js` embed on your site, you will need to check that the pymsrc option is set.
+
+To save time and effort, set the "Default pymsrc" option in the plugin settings to NPR's CDN copy of `Pym.js`: `https://pym.nprapps.org/pym.v1.min.js`
+
+### Override pymsrc
+
+Anyone who can edit a post can set the pymsrc URL on a shortcode or a block, and the pymsrc URL can be *any* resource. Browsers will try to load it as JavaScript, even if the set URL is for an image, a 404 page, or a non-`Pym.js` library. This is not good.
+
+We **strongly recommend** that you check this box, to force all `Pym.js` Embed shortcodes and blocks to use the plugin's default pymsrc.
+
+This box is not checked by default, because defaulting to overriding the pymsrc URL would potentially break existing shortcodes on sites that used this plugin before release version 1.3.2.1. If you used this plugin to create `[pym]` shortcodes before release 1.3.2.1, and wish to test your embeds before enabling the override, read [this testing advice](./upgrade-testing.md).
 
 ## Frequently Asked Questions
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -123,7 +123,9 @@ In the Gutenberg editor, the alignment options are provided by the alignment con
 For example, the shortcode `[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" id="extremely_specific_id"]` results in the following output:
 
 ```html
-<div id="extremely_specific_id" class="pym"></div><script src="http://example.org/wp-content/plugins/pym-shortcode/js/pym.v1.min.js"></script><script>var pym_0 = new pym.Parent('extremely_specific_example', 'https://blog.apps.npr.org/pym.js/examples/table/child.html', {})</script>
+<div id="extremely_specific_id" class="pym">
+...
+<script>var pym_0 = new pym.Parent('extremely_specific_example', 'https://blog.apps.npr.org/pym.js/examples/table/child.html', {})</script>
 ```
 
 ## Plugin Options

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -190,7 +190,7 @@ Or, you can specify the URL from which to load `Pym.js`.
 
 In this document, `Pym.js` is used to refer to the JavaScript library.
 
-`pym.v1.min.js` is a specific copy of that library, hosted on your server at a given URL. It's named following [NPR's `Pym.js` versioning strategy](https://github.com/nprapps/pym.js/tree/master#versioning). It is kept up to date with the CDN version of the library by this plugin's maintainers, [following these instructions](https://github.com/INN/pym-shortcode/blob/master/docs/updating-pym.md).
+`pym.v1.min.js` is a specific copy of that library, hosted on your server at a given URL. It's named following [NPR's `Pym.js` versioning strategy](https://github.com/nprapps/pym.js/tree/master#versioning). It is kept up to date with the CDN version of the library by this plugin's maintainers, [following these instructions](https://github.com/INN/pym-shortcode/blob/master/docs/maintainer-notes.md).
 
 The CDN version of `Pym.js` is at https://pym.nprapps.org/pym.v1.min.js .
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -103,7 +103,9 @@ To do the same thing with this Pym shortcode, you would write:
 For example, the shortcode `[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" class="one two three four float-left mw_50"]` results in the following output:
 
 ```html
-<div id="pym_0" class="pym one two three four float-left mw_50"></div><script src="http://example.org/wp-content/plugins/pym-shortcode/js/pym.v1.min.js"></script><script>var pym_0 = new pym.Parent('pym_0', 'https://blog.apps.npr.org/pym.js/examples/table/child.html', {})</script>
+<div id="pym_0" class="pym one two three four float-left mw_50"></div>
+...
+<script>var pym_0 = new pym.Parent('pym_0', 'https://blog.apps.npr.org/pym.js/examples/table/child.html', {})</script>
 ```
 
 If you do not want the class `'pym'` output on container elements, [add a filter](https://codex.wordpress.org/Plugin_API/Filter_Reference) to the hook `pym_shortcode_default_class` that returns an empty string.

--- a/docs/upgrade-testing.md
+++ b/docs/upgrade-testing.md
@@ -1,0 +1,59 @@
+# Testing advice for upgrading the plugin
+
+We recommend that you perform testing in a copy of your production environment, such as a staging or development server, or a local development environment. You should try to test with as complete a copy as possible, to include themes, plugins, and a copy of the database.
+
+If your live site uses an HTTPS certificate, your testing environment should use an HTTPS certificate. Talk to your hosting provider or consult your local development environment's docs for information about enabling HTTPS.
+
+## Finding posts that use the `[pym]` shortcode
+
+### site search
+
+Depending on what search engine is enabled on your site, you may be able to find pymsrc posts using the search function: `example.org/?s=pymsrc`
+
+### wp-cli
+
+If you have [wp-cli](https://wp-cli.org/) installed in your environment, you can get a list of posts using the `[pym]` shortcode by running a search using [wp post list](https://developer.wordpress.org/cli/commands/post/list/)
+
+```
+wp post list --s='[pym'
+```
+You should see a list of posts and their IDs.
+
+```
++----+------------------------------------------+-------------------+---------------------+-------------+
+| ID | post_title                               | post_name         | post_date           | post_status |
++----+------------------------------------------+-------------------+---------------------+-------------+
+| 5  | Pym Example: multiple tables and pymsrcs | pym-example-table | 2018-08-22 20:44:23 | publish     |
++----+------------------------------------------+-------------------+---------------------+-------------+
+```
+
+To find posts containg shortcode or blocks with a custom pymsrc set:
+
+```
+$ wp post list --s='pymsrc'
++----+------------------------------------------+------------------------+---------------------+-------------+
+| ID | post_title                               | post_name              | post_date           | post_status |
++----+------------------------------------------+------------------------+---------------------+-------------+
+| 5  | Pym Example: multiple tables and pymsrcs | pym-example-table      | 2018-08-22 20:44:23 | publish     |
+| 10 | Single pym child block                   | single-pym-child-block | 2018-08-29 22:52:19 | publish     |
++----+------------------------------------------+------------------------+---------------------+-------------+
+```
+
+You can change the formatting of the list and the information it contains for each post using the arguments of [wp post list](https://developer.wordpress.org/cli/commands/post/list/).
+
+As an example, here's how to use `wp post list` on a Mac to open in a browser every single post containing a pymsrc setting:
+
+```
+wp post list --s='pymsrc' --format=ids | tr "[:space:]" "\n" | xargs -I % open http://pym-shortcode.test/?p=%
+```
+
+## Testing the pymsrc override
+
+1. Enable the override option in **Settings > Pym.js Embeds Settings > Override pymsrc**
+2. Find all posts using the pymsrc option in a shortcode or block, using one of the methods above.
+3. For a representative sample of posts, or for all posts if you can, open each post in a browser.
+	1. Does the embed load correctly?
+	2. Open the browser console. Are there any notices, warnings, or errors?
+	3. 
+
+You may want to take the time to edit your embedded pages so that they all use the NPR CDN version of `Pym.js`, or use your newsroom's CDN version of `Pym.js`. You should be using [the most-recent version of `Pym.js`](http://blog.apps.npr.org/pym.js/) in any case.

--- a/docs/upgrade-testing.md
+++ b/docs/upgrade-testing.md
@@ -12,12 +12,12 @@ Depending on what search engine is enabled on your site, you may be able to find
 
 ### wp-cli
 
-If you have [wp-cli](https://wp-cli.org/) installed in your environment, you can get a list of posts using the `[pym]` shortcode by running a search using [wp post list](https://developer.wordpress.org/cli/commands/post/list/)
+If you have [wp-cli](https://wp-cli.org/) installed in your environment, you can get a list of posts using the `[pym]` shortcode by running a search using [wp post list](https://developer.wordpress.org/cli/commands/post/list/):
 
 ```
 wp post list --s='[pym'
 ```
-You should see a list of posts and their IDs.
+Your terminal should return a list of posts and their IDs:
 
 ```
 +----+------------------------------------------+-------------------+---------------------+-------------+
@@ -27,7 +27,7 @@ You should see a list of posts and their IDs.
 +----+------------------------------------------+-------------------+---------------------+-------------+
 ```
 
-To find posts containg shortcode or blocks with a custom pymsrc set:
+To find posts containing shortcode or blocks with a custom pymsrc set:
 
 ```
 $ wp post list --s='pymsrc'
@@ -41,11 +41,13 @@ $ wp post list --s='pymsrc'
 
 You can change the formatting of the list and the information it contains for each post using the arguments of [wp post list](https://developer.wordpress.org/cli/commands/post/list/).
 
-As an example, here's how to use `wp post list` on a Mac to open in a browser every single post containing a pymsrc setting:
+As an example, here's how to use `wp post list`, on a [local Valet development install running on a Mac](https://github.com/INN/docs/blob/master/projects/largo/site-setup-valet.md), to open in your default web browser every single post containing a pymsrc setting:
 
 ```
 wp post list --s='pymsrc' --format=ids | tr "[:space:]" "\n" | xargs -I % open http://pym-shortcode.test/?p=%
 ```
+
+This opened two tabs: one each for post `5` and `10`. Use this with caution if you have a lot of stories with `Pym.js` embeds; you might crash your web browser.
 
 ## Testing the pymsrc override
 

--- a/docs/upgrade-testing.md
+++ b/docs/upgrade-testing.md
@@ -57,3 +57,29 @@ wp post list --s='pymsrc' --format=ids | tr "[:space:]" "\n" | xargs -I % open h
 	3. 
 
 You may want to take the time to edit your embedded pages so that they all use the NPR CDN version of `Pym.js`, or use your newsroom's CDN version of `Pym.js`. You should be using [the most-recent version of `Pym.js`](http://blog.apps.npr.org/pym.js/) in any case.
+
+## Testing embed alignment
+
+Version 1.3.2.1 of this plugin introduced [support for WordPress' alignment CSS classes](./readme.md#align-for-wordpress-alignment-support).
+
+For advice on styling the alignment classes, see [the Gutenberg docs](https://wordpress.org/gutenberg/handbook/extensibility/theme-support/#wide-alignments-and-floats).
+
+### Shortcode testing
+
+Test your theme's alignment CSS classes with the following shortcodes:
+
+```
+[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" align=""]
+[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" align="none"]
+[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" align="left"]
+[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" align="center"]
+[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" align="right"]
+[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" align="wide"]
+[pym src="https://blog.apps.npr.org/pym.js/examples/table/child.html" align="full"]
+```
+
+You'll want to check that the embeds are positioned correctly on the page in all browsers that you support and at all viewport widths.
+
+### Block testing
+
+Test your theme's alignment CSS by creating blocks with each alignment option. Your theme may need to [declare wide alignment](https://wordpress.org/gutenberg/handbook/extensibility/theme-support/#wide-alignment) in order to see the "wide" and "full" options.

--- a/inc/info-page.php
+++ b/inc/info-page.php
@@ -5,7 +5,7 @@
  * This is available to everyone who can edit posts, because they'll need this info if they're creating new child pages for embed using the shortcode or plugin.
  */
 
-namespace INN\PymShortcode\Info;
+namespace INN\PymEmbeds\Info;
 
 /**
  * Create the option page
@@ -18,7 +18,7 @@ function register_options_page() {
 		__( 'Pym.js Embeds Plugin Information', 'pym-shortcode' ), // title of page
 		__( 'Pym.js Embeds Info', 'pym-shortcode' ), // menu text
 		'edit_posts', // capability required
-		'pym-shortcode-info', // menu slug
+		'pym-embeds-info', // menu slug
 		__NAMESPACE__ . '\options_page_callback' // callback for options page display
 	);
 }

--- a/inc/info-page.php
+++ b/inc/info-page.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * The informational page for this plugin.
+ *
+ * This is available to everyone who can edit posts, because they'll need this info if they're creating new child pages for embed using the shortcode or plugin.
+ */
+
+namespace INN\PymShortcode\Info;
+
+/**
+ * Create the option page
+ *
+ * @since 1.3.2.1
+ */
+function register_options_page() {
+	add_submenu_page(
+		'tools.php',
+		__( 'Pym plugin info', 'pym-shortcode' ), // title of page
+		__( 'Pym plugin info', 'pym-shortcode' ), // menu text
+		'edit_posts', // capability required
+		'pym-shortcode-info', // menu slug
+		__NAMESPACE__ . '\options_page_callback' // callback for options page display
+	);
+}
+add_action( 'admin_menu', __NAMESPACE__ . '\register_options_page' );
+
+/**
+ * Options page display callback
+ *
+ * @since 1.3.2.1
+ * @link https://developer.wordpress.org/plugins/settings/custom-settings-page/
+ */
+function options_page_callback() {
+	printf(
+		'<h1>%1$s</h1>',
+		esc_html( get_admin_page_title() )
+	);
+
+	printf(
+		'<p>%1$s</p>',
+		wp_kses_post( __( 'For information on how to use the block and shortcode provided by the Pym plugin, read the plugin\'s documentation <a href="https://github.com/INN/pym-shortcode/tree/master/docs">on GitHub</a>.', 'pym-shortcode' ) )
+	);
+
+	printf(
+		'<label for="local_url">%1$s</label>',
+		esc_html__( 'The URL for the copy of Pym.js hosted on this site is:', 'pym-shortcode' )
+	);
+
+	// copying how qz.com does their share links
+	printf(
+		'<input id="local_url" type="text" readonly value="%1$s" style="clear:both; width: 100%%; display: block;"/>',
+		esc_attr( pym_pymsrc_local_url() )
+	);
+}

--- a/inc/info-page.php
+++ b/inc/info-page.php
@@ -15,8 +15,8 @@ namespace INN\PymShortcode\Info;
 function register_options_page() {
 	add_submenu_page(
 		'tools.php',
-		__( 'Pym Plugin Info', 'pym-shortcode' ), // title of page
-		__( 'Pym Plugin Info', 'pym-shortcode' ), // menu text
+		__( 'Pym.js Embeds Plugin Information', 'pym-shortcode' ), // title of page
+		__( 'Pym.js Embeds Info', 'pym-shortcode' ), // menu text
 		'edit_posts', // capability required
 		'pym-shortcode-info', // menu slug
 		__NAMESPACE__ . '\options_page_callback' // callback for options page display
@@ -38,7 +38,7 @@ function options_page_callback() {
 
 	printf(
 		'<p>%1$s</p>',
-		wp_kses_post( __( 'For information on how to use the block and shortcode provided by the Pym plugin, read the plugin\'s documentation <a href="https://github.com/INN/pym-shortcode/tree/master/docs">on GitHub</a>.', 'pym-shortcode' ) )
+		wp_kses_post( __( 'For information on how to use the block and shortcode provided by the Pym.js Embeds plugin, read the plugin\'s documentation <a href="https://github.com/INN/pym-shortcode/tree/master/docs">on GitHub</a>.', 'pym-shortcode' ) )
 	);
 
 	printf(

--- a/inc/info-page.php
+++ b/inc/info-page.php
@@ -15,8 +15,8 @@ namespace INN\PymShortcode\Info;
 function register_options_page() {
 	add_submenu_page(
 		'tools.php',
-		__( 'Pym plugin info', 'pym-shortcode' ), // title of page
-		__( 'Pym plugin info', 'pym-shortcode' ), // menu text
+		__( 'Pym Plugin Info', 'pym-shortcode' ), // title of page
+		__( 'Pym Plugin Info', 'pym-shortcode' ), // menu text
 		'edit_posts', // capability required
 		'pym-shortcode-info', // menu slug
 		__NAMESPACE__ . '\options_page_callback' // callback for options page display

--- a/inc/settings-page.php
+++ b/inc/settings-page.php
@@ -87,7 +87,8 @@ function options_page_callback() {
 	?>
 		<form action="options.php" method="post">
 			<?php
-				do_settings_sections( settings_page() );
+				settings_fields( option_group() );
+				do_settings_sections( settings_section() );
 				submit_button( esc_html__( 'Save settings', 'pym-shortcode' ) );
 			?>
 		</form>
@@ -109,7 +110,7 @@ function admin_init() {
 	);
 
 	add_settings_section(
-		'pymsrc_settings',
+		settings_section(),
 		__( 'Pym.js Source Settings', 'pym-shortcode' ),
 		__NAMESPACE__ . '\pym_settings_section_callback',
 		settings_page()
@@ -120,7 +121,7 @@ function admin_init() {
 		__( 'Default pymsrc', 'pym-shortcode' ),
 		__NAMESPACE__ . '\field_default_pymsrc',
 		settings_page(), // menu slug of this page.
-		'pymsrc_settings',
+		settings_section(), // settings section slug.
 		array(
 			'label_for' => 'default_pymsrc',
 		)
@@ -131,7 +132,7 @@ function admin_init() {
 		__( 'Override pymsrc', 'pym-shortcode' ),
 		__NAMESPACE__ . '\field_override_pymsrc',
 		settings_page(), // menu slug of this page.
-		'pymsrc_settings',
+		settings_section(), // settings section slug.
 		array(
 			'label_for' => 'override_pymsrc',
 		)

--- a/inc/settings-page.php
+++ b/inc/settings-page.php
@@ -54,7 +54,7 @@ function settings_page() {
  */
 function register_options_page() {
 	add_submenu_page(
-		'tools.php',
+		'options-general.php',
 		__( 'Pym.js Embeds Plugin Settings', 'pym-shortcode' ), // title of page
 		__( 'Pym.js Embeds Settings', 'pym-shortcode' ), // menu text
 		'manage_options', // capability required

--- a/inc/settings-page.php
+++ b/inc/settings-page.php
@@ -87,8 +87,7 @@ function options_page_callback() {
 	?>
 		<form action="options.php" method="post">
 			<?php
-				settings_fields( option_group() );
-				do_settings_sections( settings_section() );
+				do_settings_sections( settings_page() );
 				submit_button( esc_html__( 'Save settings', 'pym-shortcode' ) );
 			?>
 		</form>
@@ -110,8 +109,8 @@ function admin_init() {
 	);
 
 	add_settings_section(
-		settings_section(),
-		__( 'Settings', 'pym-shortcode' ),
+		'pymsrc_settings',
+		__( 'Pym.js Source Settings', 'pym-shortcode' ),
 		__NAMESPACE__ . '\pym_settings_section_callback',
 		settings_page()
 	);
@@ -121,7 +120,7 @@ function admin_init() {
 		__( 'Default pymsrc', 'pym-shortcode' ),
 		__NAMESPACE__ . '\field_default_pymsrc',
 		settings_page(), // menu slug of this page.
-		settings_section(), // settings section slug.
+		'pymsrc_settings',
 		array(
 			'label_for' => 'default_pymsrc',
 		)
@@ -132,7 +131,7 @@ function admin_init() {
 		__( 'Override pymsrc', 'pym-shortcode' ),
 		__NAMESPACE__ . '\field_override_pymsrc',
 		settings_page(), // menu slug of this page.
-		settings_section(), // settings section slug.
+		'pymsrc_settings',
 		array(
 			'label_for' => 'override_pymsrc',
 		)
@@ -148,6 +147,10 @@ add_action( 'admin_init', __NAMESPACE__ . '\admin_init' );
  * @param Array $args Arguments passed to the section callback.
  */
 function pym_settings_section_callback( $args ) {
+	printf(
+		'<p>%1$s</p>',
+		__( 'The Pym.js JavaScript library can be provided from many sources. By default, shortcodes and blocks will use a copy of Pym.js hosted on your website to power embeds. For more information about changing the Pym.js source URL, referred to as \'pymsrc\', please <a href="https://github.com/INN/pym-shortcode/blob/master/docs/readme.md">read this plugin\'s documentation</a>.', 'pym-shortcode' )
+	);
 }
 
 /**
@@ -229,6 +232,6 @@ function field_override_pymsrc( $args ) {
 	printf(
 		'<label for="%1$s" style="display:block;clear:both; margin-top:0.5em;">%2$s</label>',
 		esc_attr( $id ),
-		esc_html__( 'Checking this box means that every Pym.js embed will use the default pymsrc URL, ignoring the pymsrc URL set in the embed\'s shortcode attributes or block settings.', 'pym-shortcode' )
+		esc_html__( 'Checking this box means that every Pym.js embed will use the default pymsrc URL, ignoring the pymsrc URL set in the embed\'s shortcode attributes or block settings. We recommend that you check this box after setting the default pymsrc URL to the CDN-provided copy of the library.', 'pym-shortcode' )
 	);
 }

--- a/inc/settings-page.php
+++ b/inc/settings-page.php
@@ -163,6 +163,7 @@ function pym_settings_section_callback( $args ) {
  * @param Mixed $value The setting.
  * @return Array The sanitized setting
  * @uses pym_pymsrc_local_url
+ * @uses pym_plugin_version
  */
 function sanitize_callback( $value ) {
 	error_log(var_export( $value, true));
@@ -175,6 +176,8 @@ function sanitize_callback( $value ) {
 	$new_value['default_pymsrc'] = ! empty( $proposed_pymsrc ) ? $proposed_pymsrc : null;
 
 	$new_value['override_pymsrc'] = ( isset( $value['override_pymsrc'] ) && 'on' === $value['override_pymsrc'] ) ? 'on': null;
+
+	$new_value['version'] = pym_plugin_version();
 
 	return $new_value;
 }

--- a/inc/settings-page.php
+++ b/inc/settings-page.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * The settings page for this plugin.
+ *
+ */
+
+namespace INN\PymEmbeds\Settings;
+
+/**
+ * Function to return the option group name.
+ *
+ * @return string The option group name.
+ * @since 1.3.2.1
+ */
+function option_group() {
+	return 'pym_embeds';
+}
+
+/**
+ * Function to return the option key under which this plugin's settings will be stored
+ *
+ * Don't change this capriciously.
+ *
+ * @return string The option_key for the wp_options table
+ * @since 1.3.2.1
+ */
+function option_key() {
+	return 'pym_embeds';
+}
+
+/**
+ * Function to return the settings section
+ *
+ * @since 1.3.2.1
+ * @return string The settings_section
+ */
+function settings_section() {
+	return 'pym-embed-settings';
+}
+
+/**
+ * Function to return the settings page slug
+ *
+ * @since 1.3.2.1
+ * @return string the settings_page
+ */
+function settings_page() {
+	return 'pym-embed-settings';
+}
+/**
+ * Create the option page
+ *
+ * @since 1.3.2.1
+ */
+function register_options_page() {
+	add_submenu_page(
+		'tools.php',
+		__( 'Pym.js Embeds Plugin Settings', 'pym-shortcode' ), // title of page
+		__( 'Pym.js Embeds Settings', 'pym-shortcode' ), // menu text
+		'manage_options', // capability required
+		settings_page(), // menu slug
+		__NAMESPACE__ . '\options_page_callback' // callback for options page display.
+	);
+}
+add_action( 'admin_menu', __NAMESPACE__ . '\register_options_page' );
+
+/**
+ * Options page display callback
+ *
+ * @since 1.3.2.1
+ * @link https://developer.wordpress.org/plugins/settings/custom-settings-page/
+ */
+function options_page_callback() {
+	// check capabilities.
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to access the Pym.js Embeds plugin\'s settings.', 'pym-shortcode' ) );
+		return;
+	}
+
+	settings_errors( 'pym_messages' );
+
+	printf(
+		'<h1>%1$s</h1>',
+		esc_html( get_admin_page_title() )
+	);
+
+	?>
+		<form action="options.php" method="post">
+			<?php
+				settings_fields( option_group() );
+				do_settings_sections( settings_section() );
+				submit_button( esc_html__( 'Save settings', 'pym-shortcode' ) );
+			?>
+		</form>
+	<?php
+}
+
+/**
+ * Register our settings
+ *
+ * @since 1.3.2.1
+ */
+function admin_init() {
+	register_setting(
+		option_group(),
+		option_key(),
+		array(
+			'sanitize_callback' => __NAMESPACE__ . '\sanitize_callback',
+		)
+	);
+
+	add_settings_section(
+		settings_section(),
+		__( 'Settings', 'pym-shortcode' ),
+		__NAMESPACE__ . '\pym_settings_section_callback',
+		settings_page()
+	);
+
+	add_settings_field(
+		'default_pymsrc',
+		__( 'Default pymsrc', 'pym-shortcode' ),
+		__NAMESPACE__ . '\field_default_pymsrc',
+		settings_page(), // menu slug of this page.
+		settings_section(), // settings section slug.
+		array(
+			'label_for' => 'default_pymsrc',
+		)
+	);
+
+	add_settings_field(
+		'override_pymsrc',
+		__( 'Override pymsrc', 'pym-shortcode' ),
+		__NAMESPACE__ . '\field_override_pymsrc',
+		settings_page(), // menu slug of this page.
+		settings_section(), // settings section slug.
+		array(
+			'label_for' => 'override_pymsrc',
+		)
+	);
+}
+add_action( 'admin_init', __NAMESPACE__ . '\admin_init' );
+
+/**
+ * Settings section callback
+ *
+ * Does nothing.
+ *
+ * @param Array $args Arguments passed to the section callback.
+ */
+function pym_settings_section_callback( $args ) {
+}
+
+/**
+ * Sanitization callback for the option_value.
+ *
+ * If the default_pymsrc isn't a valid URL or is the pym_pymsrc_local_url, blank it.
+ * If the override_pymsrc isn't 'on' indicating it's checked, blank it.
+ *
+ * @since 1.3.2.1
+ * @param Mixed $value The setting.
+ * @return Array The sanitized setting
+ * @uses pym_pymsrc_local_url
+ */
+function sanitize_callback( $value ) {
+	error_log(var_export( $value, true));
+	$new_value = array();
+
+	$proposed_pymsrc = wp_http_validate_url( $value['default_pymsrc'] );
+	if ( pym_pymsrc_local_url() === $proposed_pymsrc ) {
+		$proposed_pymsrc = null;
+	}
+	$new_value['default_pymsrc'] = ! empty( $proposed_pymsrc ) ? $proposed_pymsrc : null;
+
+	$new_value['override_pymsrc'] = ( isset( $value['override_pymsrc'] ) && 'on' === $value['override_pymsrc'] ) ? 'on': null;
+
+	return $new_value;
+}
+
+/**
+ * The field for the default Pymsrc
+ *
+ * @param Array $args The arguments passed to the settings field callback.
+ */
+function field_default_pymsrc( $args ) {
+	$settings = get_option( option_key() );
+	$id = isset( $args['label_for'] ) ? $args['label_for'] : 'default_pymsrc';
+	$id = option_key() . '[' . $id . ']';
+
+	$url = isset( $settings['default_pymsrc'] ) ? $settings['default_pymsrc'] : '';
+	printf(
+		'<input name="%1$s" style="width: 100%%;" value="%2$s" type="url" />',
+		esc_attr( $id ),
+		esc_attr( $url )
+	);
+
+	printf(
+		'<label for="%1$s" style="display:block;clear:both; margin-top:0.5em;">%2$s</label>',
+		esc_attr( $id ),
+		wp_kses_post( __( 'This URL is where Pym.js will be loaded from for all embeds that do not set a pymsrc in the shortcode attributes or block settings. NPR and the Pym.js Embed plugin maintainers recommend that you use the NPR-provided CDN for this purpose: <code>https://pym.nprapps.org/pym.v1.min.js</code>', 'pym-shortcode' ) )
+	);
+	printf(
+		'<label for="%1$s" style="display:block;clear:both; margin-top:0.5em;">%2$s</label>',
+		esc_attr( $id ),
+		sprintf(
+			// translators: %1$s is a bare URL.
+			wp_kses_post( __( 'If no pymsrc URL is set here, then the plugin-provided copy of Pym.js will be used as the default: <code>%1$s</code>', 'pym-shortcode' ) ),
+			esc_html( pym_pymsrc_local_url() )
+		)
+	);
+}
+
+/**
+ * The checkbox to force all embeds to use the default
+ *
+ * @param Array $args The arguments passed to the settings field callback.
+ */
+function field_override_pymsrc( $args ) {
+	$settings = get_option( option_key() );
+	$id = isset( $args['label_for'] ) ? $args['label_for'] : 'override_pymsrc';
+	$id = option_key() . '[' . $id . ']';
+
+	$value = isset( $settings['override_pymsrc'] ) ? $settings['override_pymsrc'] : '';
+	printf(
+		'<input name="%1$s" style="" %2$s type="checkbox" />',
+		esc_attr( $id ),
+		checked( $value, 'on', false )
+	);
+
+	printf(
+		'<label for="%1$s" style="display:block;clear:both; margin-top:0.5em;">%2$s</label>',
+		esc_attr( $id ),
+		esc_html__( 'Checking this box means that every Pym.js embed will use the default pymsrc URL, ignoring the pymsrc URL set in the embed\'s shortcode attributes or block settings.', 'pym-shortcode' )
+	);
+}

--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -58,7 +58,7 @@ function pym_shortcode( $atts = array(), $content = '', $tag = '' ) {
 	);
 
 	// What's the pymsrc for this shortcode?
-	$pymsrc = empty( $atts['pymsrc'] ) ? plugins_url( '/js/pym.v1.min.js', dirname( __FILE__ ) ) : $atts['pymsrc'];
+	$pymsrc = empty( $atts['pymsrc'] ) ? pym_pymsrc_default_url() : $atts['pymsrc'];
 
 	// If this is the first Pym element on the page, output the pymsrc script tag
 	// or if the pymsrc is set, output that.
@@ -136,4 +136,24 @@ if ( ! function_exists( 'pym_shortcode_script_footer_enqueue' ) ) {
 			20 // So that this comes after the pymsrc tag is output at priority 10.
 		);
 	}
+}
+
+/**
+ * The default URL for pymsrc, as defined in plugin settings
+ *
+ * @since 1.3.2.1
+ * @uses pym_pymsrc_local_url
+ */
+function pym_pymsrc_default_url() {
+	return pym_pymsrc_local_url();
+}
+
+/**
+ * The plugin-provided pymsrc url
+ *
+ * @since 1.3.2.1
+ * @return string The URL for /wp-content/plugins/pym-shortcode/js/pym.v1.min.js
+ */
+function pym_pymsrc_local_url() {
+	return plugins_url( '/js/pym.v1.min.js', dirname( __FILE__ ) );
 }

--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -145,6 +145,7 @@ if ( ! function_exists( 'pym_shortcode_script_footer_enqueue' ) ) {
  * @uses pym_pymsrc_local_url
  */
 function pym_pymsrc_default_url() {
+	$settings = get_option( option_key() );
 	return pym_pymsrc_local_url();
 }
 

--- a/pym-shortcode.php
+++ b/pym-shortcode.php
@@ -3,7 +3,7 @@
 Plugin Name: Pym Shortcode
 Plugin URI: https://github.com/INN/pym-shortcode
 Description: Adds a [pym src=""] shortcode to simplify use of NPR's Pym.js
-Version: 1.3.2
+Version: 1.3.2.1
 Author: The INN Nerds
 Author URI: http://nerds.inn.org/
 License: GPL Version 2 or later
@@ -14,6 +14,15 @@ Text Domain: pym_shortcode
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
 	die;
+}
+
+/**
+ * What version is this plugin?
+ *
+ * @return string The plugin version number
+ */
+function pym_plugin_version() {
+	return '1.3.2.1';
 }
 
 $includes = array(

--- a/pym-shortcode.php
+++ b/pym-shortcode.php
@@ -19,6 +19,7 @@ if ( ! defined( 'WPINC' ) ) {
 $includes = array(
 	'/inc/block.php',
 	'/inc/shortcode.php',
+	'/inc/info-page.php',
 	'/inc/class-pymsrc-output.php',
 );
 foreach ( $includes as $include ) {

--- a/pym-shortcode.php
+++ b/pym-shortcode.php
@@ -20,6 +20,7 @@ $includes = array(
 	'/inc/block.php',
 	'/inc/shortcode.php',
 	'/inc/info-page.php',
+	'/inc/settings-page.php',
 	'/inc/class-pymsrc-output.php',
 );
 foreach ( $includes as $include ) {

--- a/readme.txt
+++ b/readme.txt
@@ -19,7 +19,8 @@ Pym Shortcode will resize an iframe responsively depending on the height of its 
 
 1. In the WordPress Dashboard go to **Plugins**, then click the **Add Plugins** button and search the WordPress Plugins Directory for Pym Shortcode. Alternatively, you can download the zip file from this Github repo and upload it manually to your WordPress site.
 2. Activate the plugin through the 'Plugins' screen in WordPress
-3. Nothing to configure, just begin using Pym Shortcode!
+3. In **Settings > Pym.js Embed Settings**, decide whether you'd like to change the plugin's behavior to use a non-default source URL for `Pym.js`, and whether you'd like to prevent post authors from setting embed-specific URLs for `Pym.js`
+4. Begin embedding content!
 
 == Frequently Asked Questions ==
 
@@ -45,13 +46,34 @@ Mobile view of the WordPress post with the NPR embed using Pym Shortcode:
 
 == Changelog ==
 
-= [unreleased] =
+= [1.3.2.1] =
+
+This is a major update!
+
+Following the practice begun at plugin version 1.1.2 of [having the plugin version number match the version number of the bundled copy of `Pym.js`](https://github.com/INN/pym-shortcode/blob/master/docs/maintainer-notes.md), the first three numbers in this plugin's version do not change with this release because the `Pym.js` version has not changed. We've tacked a `.1` on to the end to denote this release. Please read the release notes and test your site as appropriate before upgrading in production.
+
+New features:
 
 * Adds a "Pym Embed" block for use in Gutenberg. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issue [#28](https://github.com/INN/pym-shortcode/issues/28).
+	* If a block is created using this plugin and Gutenberg, and Gutenberg is then disabled, the block will show a link to the embedded graphic.
+* Through the settings page, you can now serve pym.js using your newsroom's CDN or NPR's CDN! [PR #45]() for [issue #31](https://github.com/INN/pym-shortcode/issues/31).
+* Adds a settings page, available to those with the `manage_options` capability, with the following options:
+	* Change the default pymsrc URL. [PR #45]() for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
+	* Override block and shortcode pymsrc URLs with the default pymsrc URL. [PR #45]() for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
+* Adds an informational page, available to all who can make posts, that lists the plugin's default source URL for `Pym.js`. This is to make the process of building new interactives easier.
 * Shortcode now gains an `align=""` parameter, so that WordPress's generated [alignment CSS classes](https://codex.wordpress.org/CSS#WordPress_Generated_Classes) can be used on embeds. By enabling this in the shortcode, the Gutenberg Block also gains support for alignment. [PR #34](https://github.com/INN/pym-shortcode/pull/34)
 * Script tags for embeds are no longer output by `the_content()`, instead being output during `wp_footer()` by [closures](https://secure.php.net/manual/en/functions.anonymous.php) hooked on the `'wp_footer'` action. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issues [#33](https://github.com/INN/pym-shortcode/issues/33) and [#35](https://github.com/INN/pym-shortcode/issues/35).
-* The source URL for `pym.js` is no longer output by `the_content()`, instead being output during `wp_footer` by an action dedicated to the task. If different shortcodes and/or blocks on the page specify different source URLs for Pym.js, all are output (after removing duplicates), but a message is logged in the browser console. If `WP_DEBUG` is set, this message is also logged to the server log, with the post ID specified. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issues [#33](https://github.com/INN/pym-shortcode/issues/33) and [#35](https://github.com/INN/pym-shortcode/issues/35). See https://github.com/INN/pym-shortcode/tree/master/docs#ive-set-a-different-pymsrc-option-but-now-im-seeing-a-message-in-the-console
 * The script tag used to run `new pym.Parent` is now configurable. By replacing the [pluggable function](https://codex.wordpress.org/Pluggable_Functions) `pym_shortcode_script_footer_enqueue()` with your own function, you can now use alternate forms of embed code that may be required for PJAX sites or custom versions of Pym.js. This resolves issue [#19](https://github.com/INN/pym-shortcode/issues/19).
+* Adds "Requires PHP: 5.3" metadata to the plugin's `readme.txt`, since we're now using PHP namespaces for some code.
+* Adds documentation for how to test the plugin:
+	* tests to run before enabling the "override pymsrc" option in production
+	* tests to run for site compatibility with Gutenberg
+
+Changes:
+
+* The source URL for `pymjs`, known as the pymsrc URL, is now passed through [wp_http_validate_url](https://developer.wordpress.org/reference/functions/wp_http_validate_url/). [PR #45]() for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
+* The source URL for `pym.js` is no longer output by `the_content()`, instead being output during `wp_footer` by an action dedicated to the task. If different shortcodes and/or blocks on the page specify different source URLs for Pym.js, all are output (after removing duplicates), but a message is logged in the browser console. If `WP_DEBUG` is set, this message is also logged to the server log, with the post ID specified. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issues [#33](https://github.com/INN/pym-shortcode/issues/33) and [#35](https://github.com/INN/pym-shortcode/issues/35). See https://github.com/INN/pym-shortcode/tree/master/docs#ive-set-a-different-pymsrc-option-but-now-im-seeing-a-message-in-the-console
+* `docs/updating-pym.md` becomes `docs/maintainer-notes.md`
 
 = 1.3.2 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: inn_nerds
 Donate link: https://inn.org/donate
 Tags: shortcode, iframe, javascript, embeds, responsive, pym, NPR
 Requires at least: 3.0.1
+Requires PHP: 5.3
 Tested up to: 4.9.8
 Stable tag: 1.3.2
 License: GPLv2 or later


### PR DESCRIPTION
## Changes

The next release of the plugin will be 1.3.2.1.

* Adds a settings page, available to those with the `manage_options` capability, with the following options:
	* Change the default pymsrc URL. [PR #45]() for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
	* Override block and shortcode pymsrc URLs with the default pymsrc URL. [PR #45]() for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
* Through the settings page, you can now serve pym.js using your newsroom's CDN or NPR's CDN! [PR #45]() for [issue #31](https://github.com/INN/pym-shortcode/issues/31).
* Adds an informational page, available to all who can make posts, that lists the plugin's default source URL for `Pym.js`. This is to make the process of building new interactives easier.
* Adds "Requires PHP: 5.3" metadata to the plugin's `readme.txt`, since we're now using PHP namespaces for some code.
* Adds documentation for how to test the plugin:
	* tests to run before enabling the "override pymsrc" option in production
	* tests to run for site compatibility with Gutenberg
 * The source URL for `pymjs`, known as the pymsrc URL, is now passed through [wp_http_validate_url](https://developer.wordpress.org/reference/functions/wp_http_validate_url/). [PR #45]() for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
* The source URL for `pym.js` is no longer output by `the_content()`, instead being output during `wp_footer` by an action dedicated to the task. If different shortcodes and/or blocks on the page specify different source URLs for Pym.js, all are output (after removing duplicates), but a message is logged in the browser console. If `WP_DEBUG` is set, this message is also logged to the server log, with the post ID specified. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issues [#33](https://github.com/INN/pym-shortcode/issues/33) and [#35](https://github.com/INN/pym-shortcode/issues/35). See https://github.com/INN/pym-shortcode/tree/master/docs#ive-set-a-different-pymsrc-option-but-now-im-seeing-a-message-in-the-console
* `docs/updating-pym.md` becomes `docs/maintainer-notes.md`

<img width="366" alt="screen shot 2018-09-06 at 12 56 58 pm" src="https://user-images.githubusercontent.com/1754187/45172810-717cfd80-b1d4-11e8-8181-6a14f6e3c7a1.png">
<img width="368" alt="screen shot 2018-09-06 at 12 57 01 pm" src="https://user-images.githubusercontent.com/1754187/45172811-717cfd80-b1d4-11e8-8711-d4c692a3d1bd.png">
<img width="1062" alt="screen shot 2018-09-06 at 12 57 18 pm" src="https://user-images.githubusercontent.com/1754187/45172812-717cfd80-b1d4-11e8-99a0-0a1641c8c8ec.png">
<img width="1062" alt="screen shot 2018-09-06 at 12 57 30 pm" src="https://user-images.githubusercontent.com/1754187/45172813-717cfd80-b1d4-11e8-8c84-34cfcb009a4f.png">


## To do:

- [ ] check words in docs: 
    - [ ] https://github.com/INN/pym-shortcode/tree/32-settings-options/docs/readme.md
    - [ ] https://github.com/INN/pym-shortcode/blob/32-settings-options/docs/upgrade-testing.md
    - [ ] https://github.com/INN/pym-shortcode/blob/32-settings-options/docs/maintainer-notes.md
    - [ ] https://github.com/INN/pym-shortcode/blob/32-settings-options/readme.txt
- [ ] check words in settings page and info page