### PR TITLE
49 innlabs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,10 @@ We have [a helpful how-to](https://github.com/INN/docs/blob/master/how-to-work-w
 
 Additionally, you can [create issues](https://github.com/INN/largo/issues) on this repo to suggest changes or improvements.
 
-And of course you can always email us: [nerds@inn.org](mailto:nerds@inn.org).
+And of course you can always email us: [support@inn.org](mailto:support@inn.org).
 
 ### Standards
 
-- Follow all standards from the INN Nerds [coding style guide](https://github.com/INN/docs/tree/master/style-guides/code).
+- Follow all standards from the INN Labs [coding style guide](https://github.com/INN/docs/tree/master/style-guides/code).
 - Use [markdown syntax](http://daringfireball.net/projects/markdown/syntax) for all text documents.
 - Pull requests for new functionality should be accompanied by tests wherever possible.

--- a/pym-shortcode.php
+++ b/pym-shortcode.php
@@ -4,8 +4,8 @@ Plugin Name: Pym.js Embeds
 Plugin URI: https://github.com/INN/pym-shortcode
 Description: Adds a [pym src=""] shortcode to simplify use of NPR's Pym.js
 Version: 1.3.2.1
-Author: The INN Nerds
-Author URI: http://nerds.inn.org/
+Author: INN Labs
+Author URI: http://labs.inn.org/
 License: GPL Version 2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: pym-embeds

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Pym.js Embeds ===
-Contributors: inn_nerds
+Contributors: innlabs
 Donate link: https://inn.org/donate
 Tags: shortcode, iframe, javascript, embeds, responsive, pym, NPR
 Requires at least: 3.0.1


### PR DESCRIPTION
## Changes

- INN Nerds becomes INN Labs in all cases. https://profiles.wordpress.org/innlabs/
- nerds@inn.org replaced with support@inn.org

## Why

For #49 and https://secure.helpscout.net/conversation/596263242/2091/

Closes #49

## Questions

- [x] is that the correct profile name?