### PR TITLE
Pym 1.3.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This plugin allows the use of NPR's [Pym.js](http://blog.apps.npr.org/pym.js/) responsive iframe script on WordPress sites, through the use of shortcodes and Gutenberg blocks.
 
 For detailed examples, ➡️ [read the docs!](./docs/) ⬅️
+
+For a detailed changelog, [read readme.txt](./readme.txt)!

--- a/pym-shortcode.php
+++ b/pym-shortcode.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Pym.js Embeds
 Plugin URI: https://github.com/INN/pym-shortcode
-Description: Adds a [pym src=""] shortcode to simplify use of NPR's Pym.js
+Description: A WordPress solution to embed iframes that are responsive horizontally and vertically using the NPR Visuals Team's `Pym.js`.
 Version: 1.3.2.1
 Author: INN Labs
 Author URI: http://labs.inn.org/

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: shortcode, iframe, javascript, embeds, responsive, pym, NPR
 Requires at least: 3.0.1
 Requires PHP: 5.3
 Tested up to: 4.9.8
-Stable tag: 1.3.2
+Stable tag: 1.3.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -48,7 +48,7 @@ Mobile view of the WordPress post with the NPR embed using Pym.js Shortcode:
 
 == Changelog ==
 
-= [1.3.2.1] =
+= 1.3.2.1 =
 
 This is a major update!
 
@@ -59,7 +59,7 @@ New features:
 * Plugin renamed from "Pym Shortcode" to "Pym.js Embeds".
 * Adds a "Pym.js Embed" block for use in Gutenberg. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issue [#28](https://github.com/INN/pym-shortcode/issues/28).
 	* If a block is created using this plugin and Gutenberg, and Gutenberg is then disabled, the block will show a link to the embedded graphic.
-* Through the settings page, you can now serve pym.js using your newsroom's CDN or NPR's CDN! [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #31](https://github.com/INN/pym-shortcode/issues/31).
+* Through the settings page, you can now serve Pym.js using your newsroom's CDN or NPR's CDN! [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #31](https://github.com/INN/pym-shortcode/issues/31).
 * Adds a settings page, available to [those users with the `manage_options` capability](https://codex.wordpress.org/Roles_and_Capabilities#Capability_vs._Role_Table), with the following options:
 	* Change the default pymsrc URL. [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
 	* Override block and shortcode pymsrc URLs with the default pymsrc URL. [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
@@ -77,6 +77,7 @@ Changes:
 * The source URL for `pymjs`, known as the pymsrc URL, is now passed through [wp_http_validate_url](https://developer.wordpress.org/reference/functions/wp_http_validate_url/). [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
 * The source URL for `pym.js` is no longer output by `the_content()`, instead being output during `wp_footer` by an action dedicated to the task. If different shortcodes and/or blocks on the page specify different source URLs for Pym.js, all are output (after removing duplicates), but a message is logged in the browser console. If `WP_DEBUG` is set, this message is also logged to the server log, with the post ID specified. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issues [#33](https://github.com/INN/pym-shortcode/issues/33) and [#35](https://github.com/INN/pym-shortcode/issues/35). See https://github.com/INN/pym-shortcode/tree/master/docs#ive-set-a-different-pymsrc-option-but-now-im-seeing-a-message-in-the-console
 * `docs/updating-pym.md` becomes `docs/maintainer-notes.md`
+* Script tags for embeds are no longer output by `the_content()`, instead being output during `wp_footer()` by [closures](https://secure.php.net/manual/en/functions.anonymous.php) hooked on the `'wp_footer'` action. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issues [#33](https://github.com/INN/pym-shortcode/issues/33) and [#35](https://github.com/INN/pym-shortcode/issues/35).
 
 = 1.3.2 =
 
@@ -127,5 +128,3 @@ You may also want to look at NPR's Pym.js resources:
 
 * [Pym.js homepage](http://blog.apps.npr.org/pym.js/)
 * [Pym.js repo on GutHub/nprapps](https://github.com/nprapps/pym.js/)
-
-[unreleased]: https://github.com/INN/pym-shortcode/compare/v1.3.2...HEAD

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,8 @@ Mobile view of the WordPress post with the NPR embed using Pym.js Shortcode:
 
 Following the practice begun at plugin version 1.1.2 of [having the plugin version number match the version number of the bundled copy of `Pym.js`](https://github.com/INN/pym-shortcode/blob/master/docs/maintainer-notes.md), the first three numbers in this plugin's version do not change with this release because the `Pym.js` version has not changed. We've tacked a `.1` on to the end to denote this release. Please read the release notes and test your site as appropriate before upgrading in production.
 
+We wish to thank all who helped us test [the release candidate](https://github.com/INN/pym-shortcode/releases/tag/v1.3.2.1-rc1) for this version, including Mike Janssen at [Current.org](https://current.org/).
+
 New features:
 
 * Plugin renamed from "Pym Shortcode" to "Pym.js Embeds".

--- a/readme.txt
+++ b/readme.txt
@@ -50,7 +50,7 @@ Mobile view of the WordPress post with the NPR embed using Pym.js Shortcode:
 
 = 1.3.2.1 =
 
-This is a major update!
+**This is a major update! Please read the release notes.
 
 Following the practice begun at plugin version 1.1.2 of [having the plugin version number match the version number of the bundled copy of `Pym.js`](https://github.com/INN/pym-shortcode/blob/master/docs/maintainer-notes.md), the first three numbers in this plugin's version do not change with this release because the `Pym.js` version has not changed. We've tacked a `.1` on to the end to denote this release. Please read the release notes and test your site as appropriate before upgrading in production.
 
@@ -59,7 +59,7 @@ New features:
 * Plugin renamed from "Pym Shortcode" to "Pym.js Embeds".
 * Adds a "Pym.js Embed" block for use in Gutenberg. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issue [#28](https://github.com/INN/pym-shortcode/issues/28).
 	* If a block is created using this plugin and Gutenberg, and Gutenberg is then disabled, the block will show a link to the embedded graphic.
-* Through the settings page, you can now serve Pym.js using your newsroom's CDN or NPR's CDN! [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #31](https://github.com/INN/pym-shortcode/issues/31).
+* Through the settings page, you can now serve pym.js using your newsroom's CDN or NPR's CDN! [PR #45]() for [issue #31](https://github.com/INN/pym-shortcode/issues/31).
 * Adds a settings page, available to [those users with the `manage_options` capability](https://codex.wordpress.org/Roles_and_Capabilities#Capability_vs._Role_Table), with the following options:
 	* Change the default pymsrc URL. [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
 	* Override block and shortcode pymsrc URLs with the default pymsrc URL. [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
@@ -74,9 +74,14 @@ New features:
 
 Changes:
 
+
 * The source URL for `pymjs`, known as the pymsrc URL, is now passed through [wp_http_validate_url](https://developer.wordpress.org/reference/functions/wp_http_validate_url/). [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
 * The source URL for `pym.js` is no longer output by `the_content()`, instead being output during `wp_footer` by an action dedicated to the task. If different shortcodes and/or blocks on the page specify different source URLs for Pym.js, all are output (after removing duplicates), but a message is logged in the browser console. If `WP_DEBUG` is set, this message is also logged to the server log, with the post ID specified. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issues [#33](https://github.com/INN/pym-shortcode/issues/33) and [#35](https://github.com/INN/pym-shortcode/issues/35). See https://github.com/INN/pym-shortcode/tree/master/docs#ive-set-a-different-pymsrc-option-but-now-im-seeing-a-message-in-the-console
 * `docs/updating-pym.md` becomes `docs/maintainer-notes.md`
+* Script tags for embeds are no longer output by `the_content()`, instead being output during `wp_footer()` by [closures](https://secure.php.net/manual/en/functions.anonymous.php) hooked on the `'wp_footer'` action. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issues [#33](https://github.com/INN/pym-shortcode/issues/33) and [#35](https://github.com/INN/pym-shortcode/issues/35).
+
+Removed:
+
 * Script tags for embeds are no longer output by `the_content()`, instead being output during `wp_footer()` by [closures](https://secure.php.net/manual/en/functions.anonymous.php) hooked on the `'wp_footer'` action. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issues [#33](https://github.com/INN/pym-shortcode/issues/33) and [#35](https://github.com/INN/pym-shortcode/issues/35).
 
 = 1.3.2 =

--- a/readme.txt
+++ b/readme.txt
@@ -50,7 +50,7 @@ Mobile view of the WordPress post with the NPR embed using Pym.js Shortcode:
 
 = 1.3.2.1 =
 
-**This is a major update! Please read the release notes.
+**This is a major update! Please read the release notes.**
 
 Following the practice begun at plugin version 1.1.2 of [having the plugin version number match the version number of the bundled copy of `Pym.js`](https://github.com/INN/pym-shortcode/blob/master/docs/maintainer-notes.md), the first three numbers in this plugin's version do not change with this release because the `Pym.js` version has not changed. We've tacked a `.1` on to the end to denote this release. Please read the release notes and test your site as appropriate before upgrading in production.
 
@@ -61,7 +61,7 @@ New features:
 * Plugin renamed from "Pym Shortcode" to "Pym.js Embeds".
 * Adds a "Pym.js Embed" block for use in Gutenberg. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issue [#28](https://github.com/INN/pym-shortcode/issues/28).
 	* If a block is created using this plugin and Gutenberg, and Gutenberg is then disabled, the block will show a link to the embedded graphic.
-* Through the settings page, you can now serve pym.js using your newsroom's CDN or NPR's CDN! [PR #45]() for [issue #31](https://github.com/INN/pym-shortcode/issues/31).
+* Through the settings page, you can now serve Pym.js using your newsroom's CDN or NPR's CDN! [PR #45]() for [issue #31](https://github.com/INN/pym-shortcode/issues/31).
 * Adds a settings page, available to [those users with the `manage_options` capability](https://codex.wordpress.org/Roles_and_Capabilities#Capability_vs._Role_Table), with the following options:
 	* Change the default pymsrc URL. [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
 	* Override block and shortcode pymsrc URLs with the default pymsrc URL. [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
@@ -76,7 +76,6 @@ New features:
 
 Changes:
 
-
 * The source URL for `pymjs`, known as the pymsrc URL, is now passed through [wp_http_validate_url](https://developer.wordpress.org/reference/functions/wp_http_validate_url/). [PR #45](https://github.com/INN/pym-shortcode/pull/45) for [issue #8](https://github.com/INN/pym-shortcode/issues/8).
 * The source URL for `pym.js` is no longer output by `the_content()`, instead being output during `wp_footer` by an action dedicated to the task. If different shortcodes and/or blocks on the page specify different source URLs for Pym.js, all are output (after removing duplicates), but a message is logged in the browser console. If `WP_DEBUG` is set, this message is also logged to the server log, with the post ID specified. [PR #34](https://github.com/INN/pym-shortcode/pull/34) for issues [#33](https://github.com/INN/pym-shortcode/issues/33) and [#35](https://github.com/INN/pym-shortcode/issues/35). See https://github.com/INN/pym-shortcode/tree/master/docs#ive-set-a-different-pymsrc-option-but-now-im-seeing-a-message-in-the-console
 * `docs/updating-pym.md` becomes `docs/maintainer-notes.md`
@@ -89,17 +88,17 @@ Removed:
 = 1.3.2 =
 
 * *RECOMMENDED UPDATE* : Pym.js users, NPR has released an update that closes a potential security hole. We recommend everyone update to 1.3.2.
-* Update to pym.js version 1.3.2: https://github.com/nprapps/pym.js/releases/tag/v1.3.2 (Changelog at https://github.com/nprapps/pym.js/blob/v1.3.2/CHANGELOG)
+* Update to Pym.js version 1.3.2: https://github.com/nprapps/pym.js/releases/tag/v1.3.2 (Changelog at https://github.com/nprapps/pym.js/blob/v1.3.2/CHANGELOG)
 
 = 1.3.1 =
 
-* Update to pym.js version 1.3.1: https://github.com/nprapps/pym.js/releases/tag/v1.3.1 (Changelog at https://github.com/nprapps/pym.js/blob/v1.3.1/CHANGELOG)
+* Update to Pym.js version 1.3.1: https://github.com/nprapps/pym.js/releases/tag/v1.3.1 (Changelog at https://github.com/nprapps/pym.js/blob/v1.3.1/CHANGELOG)
 * (we skipped pym.js version 1.3.0: https://github.com/nprapps/pym.js/releases/tag/v1.3.0)
 
 = 1.2.2 =
 
-* Update to pym.js version 1.2.2: https://github.com/nprapps/pym.js/releases/tag/v1.2.2 (Changelog at https://github.com/nprapps/pym.js/blob/master/CHANGELOG )
-* (we skipped pym.js version 1.2.1: https://github.com/nprapps/pym.js/releases/tag/v1.2.1 )
+* Update to Pym.js version 1.2.2: https://github.com/nprapps/pym.js/releases/tag/v1.2.2 (Changelog at https://github.com/nprapps/pym.js/blob/master/CHANGELOG )
+* (we skipped Pym.js version 1.2.1: https://github.com/nprapps/pym.js/releases/tag/v1.2.1 )
 * Add `id=""` attribute to allow setting custom IDs on embeds. [#21](https://github.com/INN/pym-shortcode/issues/21)
 * Add `class=""` attribute to allow setting custom classes on embeds. [#22](https://github.com/INN/pym-shortcode/issues/22) and [#23](https://github.com/INN/pym-shortcode/issues/23).
 * Add a default class name `pym` to all embed-containing div elements output by this plugin, and a filter 'pym_shortcode_default_class' to allow changing it.
@@ -114,12 +113,12 @@ Removed:
 
 = 1.2.0 =
 
-* Update to pym.js version 1.2.0: https://github.com/nprapps/pym.js/releases/tag/v1.2.0 (Changelog at https://github.com/nprapps/pym.js/blob/v1.2.0/CHANGELOG )
+* Update to Pym.js version 1.2.0: https://github.com/nprapps/pym.js/releases/tag/v1.2.0 (Changelog at https://github.com/nprapps/pym.js/blob/v1.2.0/CHANGELOG )
 * Fixes a bug where the `pymsrc` attribute might have been ignored, for real this time. [Thanks, lchheng!](https://github.com/INN/pym-shortcode/pull/17)
 
 = 1.1.2 =
 
-* Update to pym.js version 1.1.2: https://github.com/nprapps/pym.js/releases/tag/v1.1.2
+* Update to Pym.js version 1.1.2: https://github.com/nprapps/pym.js/releases/tag/v1.1.2
 * Switch the new default url of `Pym.js` in this plugin to `js/pym.v1.min.js`, leaving the existing `js/pym.js` where it is.
 * Provide additional notes in [the documentation](https://github.com/INN/pym-shortcode/tree/master/docs) for maintainers on updating `Pym.js` in this plugin
 * Fixes a bug where the `pymsrc` attribute might have been ignored

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+#
+# This file is a WordPress.org plugin release script.
+# For more about how it works, see the documentation at
+# https://github.com/INN/docs/blob/master/projects/wordpress-plugins/release.sh.md
+#
 RELEASE_DIR=release;
 SVN_PATH=$RELEASE_DIR/svn;
 SVN_REPO="https://plugins.svn.wordpress.org/pym-shortcode/";
@@ -16,6 +21,7 @@ Gruntfile.js
 release/\*
 tests/\*
 node_modules/\*
+./\*\*/.\*
 );
 
 function ensure_release_dir() {
@@ -277,6 +283,9 @@ function help_text() {
            but bon't actually commit to the SVN repository."
   echo "";
   echo "--help:    Display this help screen and exit.";
+  echo "";
+  echo "For more information about this script, see:
+  https://github.com/INN/docs/blob/master/projects/wordpress-plugins/release.sh.md";
   echo "";
   exit 0;
 }


### PR DESCRIPTION
## Changes
- Bumps version number
- Improves readmes
- Credits some helpers
- Latest `release.sh`

## Why

For #50

## post-merge tasts
- [x] tag release: `git tag -s v1.3.2.1 -m "Pym.js Embeds version 1.3.2.1"`
- [x] deploy an update to the plugin to WordPress.org