### PR TITLE
WordPress 5.0 support, tag version 1.3.2.2

### DIFF
--- a/docs/maintainer-notes.md
+++ b/docs/maintainer-notes.md
@@ -27,3 +27,4 @@ The plugin's [version history](https://github.com/INN/pym-shortcode/releases) lo
 - 1.3.1
 - 1.3.2
 - 1.3.2.1: Gutenberg and settings page
+- 1.3.2.2: WordPress 5.0 support

--- a/inc/block.php
+++ b/inc/block.php
@@ -27,6 +27,8 @@ function pym_block_init() {
 			'wp-blocks',
 			'wp-i18n',
 			'wp-element',
+			'wp-editor',
+			'wp-components',
 		),
 		filemtime( "$dir/$block_js" )
 	);

--- a/pym-shortcode.php
+++ b/pym-shortcode.php
@@ -3,7 +3,7 @@
 Plugin Name: Pym.js Embeds
 Plugin URI: https://github.com/INN/pym-shortcode
 Description: A WordPress solution to embed iframes that are responsive horizontally and vertically using the NPR Visuals Team's `Pym.js`.
-Version: 1.3.2.1
+Version: 1.3.2.2
 Author: INN Labs
 Author URI: http://labs.inn.org/
 License: GPL Version 2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://inn.org/donate
 Tags: shortcode, iframe, javascript, embeds, responsive, pym, NPR
 Requires at least: 3.0.1
 Requires PHP: 5.3
-Tested up to: 4.9.8
-Stable tag: 1.3.2.1
+Tested up to: 5.0-beta3
+Stable tag: 1.3.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,12 @@ Mobile view of the WordPress post with the NPR embed using Pym.js Shortcode:
 ![Mobile view of the WordPress post with the NPR embed using Pym.js Shortcode](img/pym-example-phone.png)
 
 == Changelog ==
+
+= 1.3.2.2 =
+
+- Plugin is now tested against WordPress 5.0 beta 3.
+- Adds support for WordPress 5.0.
+- Fixes bug where the Pym.js Embeds block did not work in WordPress 5.0. [PR #58](https://github.com/INN/pym-shortcode/pulls/58) for [issue #57](https://github.com/INN/pym-shortcode/issues/57).
 
 = 1.3.2.1 =
 


### PR DESCRIPTION
## Changes

- Fixes #57, where the plugin depended on a few JS libraries that were enqueued in Gutenberg-as-plugin but not in Gutenberg-in-WordPress
- bumps version to 1.3.2.2

## Why

Fixes #57.

## Testing/Questions

Steps to test this PR:

1. Install/activate WordPress 5.0-beta1, 5.0-beta2, 5.0-beta3 or later
2. activate this plugin
3. go to a post editor
4. add a Pym.js Embeds block to the editor
5. Check the browser javascript console to make sure there are no errors.

## post-merge tasks

- [x] `git tag -s v1.3.2.2 -m "Pym.js Embeds version 1.3.2.2"`
- [x] `release.sh`
