### PR TITLE
Add AMP-compatibility to pym shortcodes/blocks/raw embeds

### DIFF
--- a/inc/amp.php
+++ b/inc/amp.php
@@ -66,30 +66,30 @@ add_action( 'do_shortcode_tag', __NAMESPACE__ . '\convert_shortcode_to_ampiframe
  * @return string AMP-iframe HTML.
  */
 function get_pym_ampiframe( $src ) {
-		ob_start();
-		?>
-		<amp-iframe 
-			src='<?php echo esc_url( $src ); ?>'
-			layout='responsive'
-			width='1'
-			height='1'
-			sandbox='allow-scripts allow-same-origin'
-			frameborder='0'
-			resizable
+	ob_start();
+	?>
+	<amp-iframe 
+		src='<?php echo esc_url( $src ); ?>'
+		layout='responsive'
+		width='1'
+		height='1'
+		sandbox='allow-scripts allow-same-origin'
+		frameborder='0'
+		resizable
+	>
+		<div 
+			overflow 
+			tabindex=0 
+			aria-label='<?php esc_attr_e( 'Load interactive graphic', 'pym-embeds' ); ?>'
+			placeholder
+			style='width:100%; text-align:center; padding-top:50%; background:rgba(0,0,0,.7); color:#FFF; font-weight:bold'
 		>
-			<div 
-				overflow 
-				tabindex=0 
-				aria-label='<?php esc_attr_e( 'Load interactive graphic', 'pym-embeds' ); ?>'
-				placeholder
-				style='width:100%; text-align:center; padding-top:50%; background:rgba(0,0,0,.7); color:#FFF; font-weight:bold'
-			>
-				<?php esc_html_e( 'Load interactive graphic', 'pym-embeds' ); ?>
-			</div>
-		</amp-iframe>
-		<?php
+			<?php esc_html_e( 'Load interactive graphic', 'pym-embeds' ); ?>
+		</div>
+	</amp-iframe>
+	<?php
 
-		return ob_get_clean();
+	return ob_get_clean();
 }
 
 /**

--- a/inc/amp.php
+++ b/inc/amp.php
@@ -66,6 +66,18 @@ add_action( 'do_shortcode_tag', __NAMESPACE__ . '\convert_shortcode_to_ampiframe
  * @return string AMP-iframe HTML.
  */
 function get_pym_ampiframe( $src ) {
+	$src_domain_parts  = parse_url( $src );
+	$site_domain_parts = parse_url( get_site_url() );
+
+	if ( ! $src_domain_parts ) {
+		return '';
+	}
+
+	$sandbox = 'allow-scripts';
+	if ( strcasecmp( $src_domain_parts['host'], $site_domain_parts['host'] ) ) {
+		$sandbox .= ' allow-same-origin';
+	}
+
 	ob_start();
 	?>
 	<amp-iframe 
@@ -73,7 +85,7 @@ function get_pym_ampiframe( $src ) {
 		layout='responsive'
 		width='1'
 		height='1'
-		sandbox='allow-scripts allow-same-origin'
+		sandbox='<?php echo esc_attr( $sandbox ); ?>'
 		frameborder='0'
 		resizable
 	>

--- a/inc/amp.php
+++ b/inc/amp.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * AMP-compatibility for this plugin.
+ *
+ * @package pym-embeds
+ */
+
+namespace INN\PymEmbeds\AMP;
+
+/**
+ * Handle pym.js blocks and raw HTML blocks on AMP pages.
+ *
+ * @param  string $output HTML block output.
+ * @param  array  $block Block attributes and information.
+ * @return string HTML block output.
+ */
+function convert_block_to_ampiframe( $output, $block ) {
+	if ( ! is_amp() ) {
+		return $output;
+	}
+
+	if ( 'core/html' === $block['blockName'] ) {
+		$pym_src_regex = '~data-pym-src=[\'"]([^\'"]*)~';
+		$is_match      = preg_match( $pym_src_regex, $block['innerHTML'], $matches );
+		if ( ! $is_match ) {
+			return $output;
+		}
+
+		$pym_src = $matches[1];
+	} elseif ( 'pym-shortcode/pym' === $block['blockName'] ) {
+		$pym_src = $block['attrs']['src'];
+	} else {
+		return $output;
+	}
+
+	return get_pym_ampiframe( $pym_src );
+}
+add_action( 'render_block', __NAMESPACE__ . '\convert_block_to_ampiframe', 10, 2 );
+
+/**
+ * Handle pym.js shortcode on AMP pages.
+ *
+ * @param  string $output HTML shortcode output.
+ * @param  string $tag Shortcode tag.
+ * @param  array  $attributes Shortcode attributes.
+ * @return string HTML shortcode output.
+ */
+function convert_shortcode_to_ampiframe( $output, $tag, $attributes ) {
+	if ( ! is_amp() || 'pym' !== $tag ) {
+		return $output;
+	}
+
+	if ( empty( $attributes['src'] ) ) {
+		return $output;
+	}
+
+	return get_pym_ampiframe( $attributes['src'] );
+}
+add_action( 'do_shortcode_tag', __NAMESPACE__ . '\convert_shortcode_to_ampiframe', 10, 3 );
+
+/**
+ * Build an amp-iframe out of pym.js iframe source. This is a pretty solid solution until native pym.js AMP compatibility.
+ *
+ * @see    https://github.com/ampproject/amphtml/issues/22714
+ * @param  string $src iframe src.
+ * @return string AMP-iframe HTML.
+ */
+function get_pym_ampiframe( $src ) {
+		ob_start();
+		?>
+		<amp-iframe 
+			src='<?php echo esc_url( $src ); ?>'
+			layout='responsive'
+			width='1'
+			height='1'
+			sandbox='allow-scripts allow-same-origin'
+			frameborder='0'
+			resizable
+		>
+			<div 
+				overflow 
+				tabindex=0 
+				aria-label='<?php esc_attr_e( 'Load interactive graphic', 'pym-embeds' ); ?>'
+				placeholder
+				style='width:100%; text-align:center; padding-top:50%; background:rgba(0,0,0,.7); color:#FFF; font-weight:bold'
+			>
+				<?php esc_html_e( 'Load interactive graphic', 'pym-embeds' ); ?>
+			</div>
+		</amp-iframe>
+		<?php
+
+		return ob_get_clean();
+}
+
+/**
+ * Check whether the current page is an AMP page.
+ *
+ * @return bool True if AMP page.
+ */
+function is_amp() {
+	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+}

--- a/inc/amp.php
+++ b/inc/amp.php
@@ -112,12 +112,12 @@ function get_pym_ampiframe( $src, $atts = array() ) {
 			frameborder='0'
 			resizable
 		>
+			<div placeholder><?php esc_html_e( 'Interactive graphic', 'pym-embeds' ); ?></div>
 			<div 
 				overflow 
 				tabindex=0 
 				aria-label='<?php esc_attr_e( 'Load interactive graphic', 'pym-embeds' ); ?>'
-				placeholder
-				style='width:100%; text-align:center; padding-top:50%; background:rgba(0,0,0,.7); color:#FFF; font-weight:bold'
+				style='padding: .5em; background:rgba(0,0,0,.7); color:#FFF; font-weight:bold;'
 			>
 				<?php esc_html_e( 'Load interactive graphic', 'pym-embeds' ); ?>
 			</div>

--- a/inc/amp.php
+++ b/inc/amp.php
@@ -10,6 +10,7 @@ namespace INN\PymEmbeds\AMP;
 /**
  * Handle pym.js blocks and raw HTML blocks on AMP pages.
  *
+ * @since  1.3.2.3
  * @param  string $output HTML block output.
  * @param  array  $block Block attributes and information.
  * @return string HTML block output.
@@ -40,6 +41,7 @@ add_action( 'render_block', __NAMESPACE__ . '\convert_block_to_ampiframe', 10, 2
 /**
  * Handle pym.js shortcode on AMP pages.
  *
+ * @since  1.3.2.3
  * @param  string $output HTML shortcode output.
  * @param  string $tag Shortcode tag.
  * @param  array  $attributes Shortcode attributes.
@@ -61,6 +63,7 @@ add_action( 'do_shortcode_tag', __NAMESPACE__ . '\convert_shortcode_to_ampiframe
 /**
  * Build an amp-iframe out of pym.js iframe source. This is a pretty solid solution until native pym.js AMP compatibility.
  *
+ * @since  1.3.2.3
  * @see    https://github.com/ampproject/amphtml/issues/22714
  * @param  string $src iframe src.
  * @return string AMP-iframe HTML.
@@ -107,6 +110,7 @@ function get_pym_ampiframe( $src ) {
 /**
  * Check whether the current page is an AMP page.
  *
+ * @since  1.3.2.3
  * @return bool True if AMP page.
  */
 function is_amp() {

--- a/pym-shortcode.php
+++ b/pym-shortcode.php
@@ -31,6 +31,7 @@ $includes = array(
 	'/inc/info-page.php',
 	'/inc/settings-page.php',
 	'/inc/class-pymsrc-output.php',
+	'/inc/amp.php',
 );
 foreach ( $includes as $include ) {
 	if ( 0 === validate_file( dirname( __FILE__ ) . $include ) ) {


### PR DESCRIPTION
## Changes

<!-- what changed? -->

- This PR brings the Pym.js AMP-compatibility tweaks [from Newspack](https://github.com/Automattic/newspack-plugin/pull/276) to this plugin.
- It converts the Pym shortcode, Pym block, and Pym embeds in the raw HTML block into AMP-compatible versions of the same embed on AMP pages.
- In the page being embedded, the following snippet should be added to the bottom:
```
<script>window.addEventListener( 'load', () => {
    function sendEmbedSize() {
        window.parent.postMessage({
            sentinel: 'amp',
            type: 'embed-size',
            height: document.body.scrollHeight
        }, '*');
    }

    sendEmbedSize();

    // Try to make sure elements created dynamically (e.g. graphics) are sized properly.
    setTimeout( sendEmbedSize, 500 );

    // Update embed size after clicks.
    document.addEventListener( 'click', sendEmbedSize, { passive: true } );
} );
</script>
```
If the snippet is not added, the embed will be rendered in a square aspect ratio but will otherwise continue working correctly. When AMP gets native Pym-compatibility, this step will ideally not be required any more. The snippet shouldn't affect anything on non-AMP pages.

## Why

<!-- why did it change? -->

Closes #59 

## Testing/Questions

Questions that need to be answered before merging:

- How does the versioning scheme work for this plugin? What should I add for `@since` in the new functions?

Steps to test this PR:

0. Install and activate the official [AMP plugin](https://wordpress.org/plugins/amp/). For testing, it's easiest if you set the Website Mode in WP-Admin > AMP > General to 'Transitional' mode so you can flip between AMP and non-AMP versions of the same page.
1. Add the following code to a block-editor-enabled page (in details):

<details>

```
<!-- wp:paragraph -->
<p><a title="Atque." href="http://hills.com/soluta-corrupti-inventore-in-nulla-nisi-fuga">Minima assumenda sed est natus ut.</a> quidem optio neque eum Odio sed sapiente ut recusandae molestiae. Sed laboriosam quas veniam. Error soluta vel Est eum dicta nesciunt quaerat saepe. Quaerat aut et officia Esse deserunt voluptate ea possimus Nihil quia ut doloribus dicta repudiandae. Dolorem soluta perferendis odit. Quia ut consequuntur eum ea harum. Quia expedita voluptates repellat omnis est. Corporis cum adipisci ut. Laboriosam voluptatibus eligendi recusandae ducimus molestias. voluptas adipisci ipsam. Corporis voluptatibus unde facilis repellendus quia neque <a title="Expedita ipsam alias nisi tenetur dolorem." href="http://www.hahn.com/nemo-tenetur-debitis-porro-aut-perferendis-esse-facere">Impedit illo non dignissimos nemo</a></p>
<!-- /wp:paragraph -->

<!-- wp:html -->
<div id="senate" data-pym-src="https://s3.us-west-2.amazonaws.com/projects.oklahomawatch.org/oklahoma-legislature/senate.html"></div>
<!-- /wp:html -->

<!-- wp:paragraph -->
<p>Quasi nihil in assumenda qui amet eum Et ut qui iusto maiores. Rem sint unde quasi. Earum pariatur sunt sed consequatur <a href="http://luettgen.com/enim-molestias-hic-officiis-incidunt-corporis-vel">Expedita</a> omnis harum <a href="http://fay.com/dolor-libero-enim-ducimus-ut.html">dolores. Blanditiis</a> temporibus rerum debitis quia ipsam Quaerat distinctio est voluptatem aut expedita. <a href="http://hane.info/">rerum ut numquam laborum</a> Aut temporibus harum Sed suscipit ut nam. Excepturi aut assumenda accusantium voluptates. Veniam amet est optio harum et Ut voluptatem inventore enim velit itaque. qui delectus deleniti corporis. <a href="http://price.biz/dolor-dolor-hic-vel-ea-unde-architecto-nesciunt.html">molestiae</a> sed non. Et voluptate sunt dicta sit voluptas deserunt in. beatae natus quos ad. Necessitatibus iste molestiae harum <a href="https://anderson.org/eum-ad-minima-error-numquam-alias.html">Eaque et eum et nulla. Est est ab</a> magnam. Eos eaque eligendi ut illum molestias. Omnis totam quisquam temporibus sit sit. Cum consequatur omnis nobis officia.</p>
<!-- /wp:paragraph -->

<!-- wp:pym-shortcode/pym {"src":"https://s3.us-west-2.amazonaws.com/projects.oklahomawatch.org/oklahoma-legislature/senate.html"} -->
<a href="https://s3.us-west-2.amazonaws.com/projects.oklahomawatch.org/oklahoma-legislature/senate.html" class="wp-block-pym-shortcode-pym">https://s3.us-west-2.amazonaws.com/projects.oklahomawatch.org/oklahoma-legislature/senate.html</a>
<!-- /wp:pym-shortcode/pym -->

<!-- wp:paragraph -->
<p>Quasi nihil in assumenda qui amet eum Et ut qui iusto maiores. Rem sint unde quasi. Earum pariatur sunt sed consequatur <a href="http://luettgen.com/enim-molestias-hic-officiis-incidunt-corporis-vel">Expedita</a> omnis harum <a href="http://fay.com/dolor-libero-enim-ducimus-ut.html">dolores. Blanditiis</a> temporibus rerum debitis quia ipsam Quaerat distinctio est voluptatem aut expedita. <a href="http://hane.info/">rerum ut numquam laborum</a> Aut temporibus harum Sed suscipit ut nam. Excepturi aut assumenda accusantium voluptates. Veniam amet est optio harum et Ut voluptatem inventore enim velit itaque. qui delectus deleniti corporis. <a href="http://price.biz/dolor-dolor-hic-vel-ea-unde-architecto-nesciunt.html">molestiae</a> sed non. Et voluptate sunt dicta sit voluptas deserunt in. beatae natus quos ad. Necessitatibus iste molestiae harum <a href="https://anderson.org/eum-ad-minima-error-numquam-alias.html">Eaque et eum et nulla. Est est ab</a> magnam. Eos eaque eligendi ut illum molestias. Omnis totam quisquam temporibus sit sit. Cum consequatur omnis nobis officia.</p>
<!-- /wp:paragraph -->

<!-- wp:shortcode -->
[pym src='https://s3.us-west-2.amazonaws.com/projects.oklahomawatch.org/oklahoma-legislature/senate.html']
<!-- /wp:shortcode -->
```

</details>
3. View on the frontend in AMP and regular mode. You should see an interactive map each place there is a Pym.js embed.
<img width="540" alt="Screen Shot 2019-09-18 at 11 29 51 AM" src="https://user-images.githubusercontent.com/7317227/65176276-4d6c1300-da09-11e9-9d5b-373a94b0d10c.png">

**To test resizing:**
1. Add the following snippet to the footer of the site/page you want to embed:

<details>

```
<script>window.addEventListener( 'load', () => {
    function sendEmbedSize() {
        window.parent.postMessage({
            sentinel: 'amp',
            type: 'embed-size',
            height: document.body.scrollHeight
        }, '*');
    }

    sendEmbedSize();

    // Try to make sure elements created dynamically (e.g. graphics) are sized properly.
    setTimeout( sendEmbedSize, 500 );

    // Update embed size after clicks.
    document.addEventListener( 'click', sendEmbedSize, { passive: true } );
} );
</script>
```

</details>

2. In AMP-mode, view the page. If the graphic is not directly in the viewport when the page loads, it should automatically be resized correctly. If it is in the viewport when the page loads, you should see something like this:
<img width="456" alt="Screen Shot 2019-09-18 at 11 29 07 AM" src="https://user-images.githubusercontent.com/7317227/65176603-ee5ace00-da09-11e9-9070-bdee917ebe35.png">
3. Clicking on that will resize the height of the graphic correctly:
<img width="492" alt="Screen Shot 2019-09-18 at 11 29 22 AM" src="https://user-images.githubusercontent.com/7317227/65176626-fe72ad80-da09-11e9-884f-26d75f9cbbe8.png">
