### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,36 @@
 ## Changes
 
-<!-- what changed? -->
+This pull request makes the following changes:
 
-- 
+- <!-- what changed? -->
 
 ## Why
 
-<!-- why did it change? -->
-
+<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
+<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
 For #
 
 ## Testing/Questions
 
+Features that this PR affects:
+
+- 
+
+<!-- If there are no questions, please remove the questions section. -->
 Questions that need to be answered before merging:
 
+- [ ] Is this PR targeting the correct branch in this repository?
+- [ ] Does this work for the test cases provided in https://github.com/INN/pym-shortcode/blob/master/docs/maintainer-notes.md#testing-before-release ?
 - [ ] 
 
 Steps to test this PR:
 
-1. 
+1. <!-- list any configuration changes, settings, test content, or other things necessary to test this change. -->
+
+## Additional information
+
+INN Member/Labs Client requesting: (if applicable)
+
+- [ ] Contributor has read INN's [GitHub code of conduct](https://github.com/INN/.github/blob/master/CODE_OF_CONDUCT.md)
+- [ ] Contributor would like to be mentioned in the release notes as: (fill in this blank)
+- [ ] Contributor agrees to the license terms of this repository.


### PR DESCRIPTION
Resolves https://github.com/INN/pym-shortcode/issues/63

## Changes

<!-- what changed? -->

- Updates the PR template to match https://github.com/INN/pym-shortcode/blob/master/.github/pull_request_template.md plus a reference to the test cases in https://github.com/INN/pym-shortcode/blob/master/docs/maintainer-notes.md#testing-before-release

## Why

<!-- why did it change? -->

Because #62 made me realize that this PR template was missing things that were in INN's org-wide PR template.