### PR TITLE
Wrap the always-visible textControl in a PanelBody so that it has the correct padding

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -20,6 +20,7 @@
 	 * Text tools
 	 */
 	var TextControl = wp.components.TextControl;
+	var PanelBody = wp.components.PanelBody;
 
 	/**
 	 * The sidebar controls I think?
@@ -121,20 +122,19 @@
 						onChange: ( value ) => { props.setAttributes( { src: value } ); },
 					} )
 				),
-				/*
-				 * InspectorControls lets you add controls to the Block sidebar. In this case,
-				 * we're adding a TextControl, which lets us edit the 'foo' attribute (which
-				 * we defined in the PHP). The onChange property is a little bit of magic to tell
-				 * the block editor to update the value of our 'foo' property, and to re-render
-				 * the block.
-				 */
 				el( InspectorControls, {},
-					el( TextControl, {
-						label: __( 'Pym.js Child URL' ),
-						value: props.attributes.src,
-						placeholder: __( 'What is the URL of your Pym.js child page?' ),
-						onChange: ( value ) => { props.setAttributes( { src: value } ); },
-					} ),
+					el(
+						PanelBody, // inserting a PanelBody here for the presentational classes, so that it matches the display of InspectorAdvancedControls children
+						{
+							initialOpen: true,
+						},
+						el( TextControl, {
+							label: __( 'Pym.js Child URL' ),
+							value: props.attributes.src,
+							placeholder: __( 'What is the URL of your Pym.js child page?' ),
+							onChange: ( value ) => { props.setAttributes( { src: value } ); },
+						} )
+					)
 				),
 				el( InspectorAdvancedControls, {},
 					el( TextControl, {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://inn.org/donate
 Tags: shortcode, iframe, javascript, embeds, responsive, pym, NPR
 Requires at least: 3.0.1
 Requires PHP: 5.3
-Tested up to: 5.3.2
+Tested up to: 5.4
 Stable tag: 1.3.2.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -49,6 +49,10 @@ Mobile view of the WordPress post with the NPR embed using Pym.js Shortcode:
 ![Mobile view of the WordPress post with the NPR embed using Pym.js Shortcode](img/pym-example-phone.png)
 
 == Changelog ==
+
+= [next] =
+
+- Fixes a presentational error in the Pym.js Embeds Block's block inspector control within the editor. PR [#74](https://github.com/INN/pym-shortcode/pull/74) for issue [#72](https://github.com/INN/pym-shortcode/issues/72).
 
 = 1.3.2.3 =
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Wraps the non-advanced controls in a `PanelBody` element so that the Pym.js Child URL control doesn't overflow its container
- Bumps "Tested up to:" to 5.4.
- Starts changelog for the `[next]` release, which will likely be 1.3.2.4.

Before:

![Screen Shot 2020-03-19 at 19 07 23](https://user-images.githubusercontent.com/1754187/77122783-e4477580-6a14-11ea-809d-ecfa7b86cb8d.png)

After:

![Screen Shot 2020-03-19 at 22 18 22](https://user-images.githubusercontent.com/1754187/77130762-9429dc80-6a2f-11ea-8549-8e99adc04edd.png)


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #72, fixing a visual regression in WP 5.4

## Testing/Questions

Features that this PR affects:

- the block inspector controls

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Does this work for the test cases provided in https://github.com/INN/pym-shortcode/blob/master/docs/maintainer-notes.md#testing-before-release ?

Steps to test this PR:

1. View a Pym.js Embeds block's sidebar controls under `master`, and under this branch.