### PR TITLE
Bump version number to 1.3.2.4, and improve release checklist.

### DIFF
--- a/docs/maintainer-notes.md
+++ b/docs/maintainer-notes.md
@@ -29,6 +29,7 @@ The plugin's [version history](https://github.com/INN/pym-shortcode/releases) lo
 - 1.3.2.1: Gutenberg and settings page
 - 1.3.2.2: WordPress 5.0 support
 - 1.3.2.3: AMP support
+- 1.3.2.4: minor bugfix for WP 5.4
 
 ## Release checklist
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -6,7 +6,7 @@ Drawing from Largo's 0.7.0 release checklist issue https://github.com/INN/largo/
 - [ ] check for [upstream updates to `release.sh` in INN/docs](https://github.com/INN/docs/blob/master/projects/wordpress-plugins/release.sh.md) and copy them into this plugin
 - [ ] write release announcement
     - [ ] GitHub release drafted
-        - can be copied from `changelog.md`
+        - can be copied from `release.txt`
         - [ ] includes encouragement to say hi if you're using the plugin. (This fulfills the "who's using our stuff?" goal in https://github.com/INN/largo/issues/1495)
     - [ ] labs.inn.org blog post written and saved as draft, based on changelog
     - [ ] MailChimp campaign for Largo User mailing list drafted: https://github.com/INN/largo/issues/1796
@@ -35,7 +35,11 @@ The owner of the release needs to complete the following steps **BEFORE** mergin
     - [ ] in plugin description comment
 - [ ] bump version number
     - [ ] in readme.txt
-    - [ ] in pym-shortcode.php
+        - [ ] `Stable tag`
+        - [ ] changelog
+    - [ ] in pym-shortcode.php:
+        - [ ] `Version`
+        - [ ] `pym_plugin_version()`
     - [ ] in readme.md
     - [ ] in docs/maintainer-notes.md
 - [ ] testing as described in https://github.com/INN/pym-shortcode/blob/master/docs/maintainer-notes.md

--- a/pym-shortcode.php
+++ b/pym-shortcode.php
@@ -3,9 +3,9 @@
 Plugin Name: Pym.js Embeds
 Plugin URI: https://github.com/INN/pym-shortcode
 Description: A WordPress block and shortcode for embedding iframes that are responsive horizontally and vertically using the NPR Visuals Team's `Pym.js`.
-Version: 1.3.2.3
+Version: 1.3.2.4
 Author: INN Labs
-Author URI: http://labs.inn.org/
+Author URI: https://labs.inn.org/
 License: GPL Version 2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: pym-embeds
@@ -22,7 +22,7 @@ if ( ! defined( 'WPINC' ) ) {
  * @return string The plugin version number
  */
 function pym_plugin_version() {
-	return '1.3.2.3';
+	return '1.3.2.4';
 }
 
 $includes = array(

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: shortcode, iframe, javascript, embeds, responsive, pym, NPR
 Requires at least: 3.0.1
 Requires PHP: 5.3
 Tested up to: 5.4
-Stable tag: 1.3.2.3
+Stable tag: 1.3.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -50,8 +50,9 @@ Mobile view of the WordPress post with the NPR embed using Pym.js Shortcode:
 
 == Changelog ==
 
-= [next] =
+= 1.3.2.4 =
 
+- Now tested up to WordPress 5.4 and Gutenberg 7.8.
 - Fixes a presentational error in the Pym.js Embeds Block's block inspector control within the editor. PR [#74](https://github.com/INN/pym-shortcode/pull/74) for issue [#72](https://github.com/INN/pym-shortcode/issues/72).
 
 = 1.3.2.3 =


### PR DESCRIPTION
Also make Labs website URL use HTTPS.

## Changes

This pull request makes the following changes:

- bumps version number to 1.3.2.4
- includes #74 for a visual fix
- includes #72 for testing against WP 5.4
- improves specificity of draft release checklist to capture a few things I almost missed
- updates a URL that had been pointed out as not being HTTPS by one of the Newspack contributors

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #71 

## Testing/Questions

Features that this PR affects:

- version number

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] ~Does this work for the test cases provided in https://github.com/INN/pym-shortcode/blob/master/docs/maintainer-notes.md#testing-before-release ?~ tested in #72 

Steps to test this PR:

1. check it out!
2. view version number in Plugins list to make sure it's up to date with this PR.